### PR TITLE
Cmake improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if(Boost_FOUND)
     add_definitions(-DUSEBOOST)
 endif()
 
+# CMake options
+set(AnalysisTree_BUILD_TESTS OFF CACHE BOOL "Build tests for the AnalysisTree")
+set(AnalysisTree_BUILD_EXAMPLES ON CACHE BOOL "Build examples for the AnalysisTree")
+
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb -g -DDEBUG -D__DEBUG -Wall -Wextra --coverage")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ftree-vectorize -ffast-math -DNODEBUG")
@@ -43,13 +47,16 @@ include(${ROOT_USE_FILE})
 
 add_subdirectory(core)
 add_subdirectory(infra)
-add_subdirectory(examples)
 
-IF (CMAKE_BUILD_TYPE MATCHES Debug)
+if(AnalysisTree_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+if(AnalysisTree_BUILD_TESTS)
     include(GoogleTest)
     enable_testing()
     add_subdirectory(test)
-ENDIF (CMAKE_BUILD_TYPE MATCHES Debug)
+endif()
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.0)
+# Minimum 3.5 version is determined by cmake -E copy_if_different command
+# that was used to copy headers to the build directory:
+# multiple files are supported since cmake 3.5
+cmake_minimum_required(VERSION 3.5)
 project(AnalysisTree CXX)
 set(PROJECT_VERSION 1.1)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,6 +19,18 @@ list(APPEND HEADERS "Constants.hpp")
 add_library(AnalysisTreeBase SHARED ${SOURCES} G__AnalysisTreeBase.cxx)
 ROOT_GENERATE_DICTIONARY(G__AnalysisTreeBase ${HEADERS} LINKDEF AnalysisTreeCoreLinkDef.h)
 target_link_libraries(AnalysisTreeBase ${ROOT_LIBRARIES})
+add_custom_command(TARGET AnalysisTreeBase PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${CMAKE_BINARY_DIR}/include/AnalysisTree
+        COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${HEADERS} ${CMAKE_BINARY_DIR}/include/AnalysisTree
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_include_directories(AnalysisTreeBase
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+        )
+
 
 install(TARGETS AnalysisTreeBase EXPORT AnalysisTreeTargets
         LIBRARY DESTINATION lib

--- a/infra/CMakeLists.txt
+++ b/infra/CMakeLists.txt
@@ -27,6 +27,17 @@ add_library(AnalysisTreeInfra SHARED ${SOURCES} G__AnalysisTreeInfra.cxx)
         
 ROOT_GENERATE_DICTIONARY(G__AnalysisTreeInfra ${HEADERS} LINKDEF AnalysisTreeInfraLinkDef.h)
 target_link_libraries(AnalysisTreeInfra ${ROOT_LIBRARIES} AnalysisTreeBase)
+add_custom_command(TARGET AnalysisTreeInfra PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${CMAKE_BINARY_DIR}/include/AnalysisTree
+        COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${HEADERS} ${CMAKE_BINARY_DIR}/include/AnalysisTree
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+target_include_directories(AnalysisTreeInfra
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+        )
 
 install(TARGETS AnalysisTreeInfra EXPORT AnalysisTreeTargets
         LIBRARY DESTINATION lib


### PR DESCRIPTION
I made few changes in CMake to get better support of AnalysisTree as a subproject. 

- structure of include directories is reproduced in CMAKE_BINARY_DIR. Now user can include AnalysisTree headers in the same way for external installation of the AnalysisTree and for temporary build in case AnalysisTree is built using new CMake feature FetchContent or using Git-submodules + add_subdirectory.
- add support of modern CMake