### PR TITLE
More secure way to get mass of a particle

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,7 +18,7 @@ list(APPEND HEADERS "Constants.hpp" "ToyMC.hpp")
 
 add_library(AnalysisTreeBase SHARED ${SOURCES} G__AnalysisTreeBase.cxx)
 ROOT_GENERATE_DICTIONARY(G__AnalysisTreeBase ${HEADERS} LINKDEF AnalysisTreeCoreLinkDef.h)
-target_link_libraries(AnalysisTreeBase ${ROOT_LIBRARIES})
+target_link_libraries(AnalysisTreeBase ${ROOT_LIBRARIES} ROOT::EG)
 add_custom_command(TARGET AnalysisTreeBase PRE_BUILD
         COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${CMAKE_BINARY_DIR}/include/AnalysisTree
         COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${HEADERS} ${CMAKE_BINARY_DIR}/include/AnalysisTree

--- a/core/Constants.hpp
+++ b/core/Constants.hpp
@@ -5,6 +5,7 @@
 #include <map>
 
 #include <Rtypes.h>
+#include <TDatabasePDG.h>
 
 //#include <TDatabasePDG.h>
 //class TDataBasePDG;
@@ -22,39 +23,17 @@ constexpr ShortInt_t UndefValueShort = -999;
 constexpr Integer_t UndefValueInt = -999;
 constexpr Floating_t SmallNumber = 1e-6f;
 
-const std::map<int, float> MassMap = {{11, 0.000511},// e
-                                      {211, 0.13957},// pi^{+,-}
-                                      {111, 0.13498},// pi^0
-                                      {130, 0.4976},
-                                      {310, 0.4976},
-                                      {311, 0.4976},
-                                      {321, 0.493677},  // K^{+,-}
-                                      {2212, 0.938272}, // p, anti-p
-                                      {2112, 0.939565}, // n
-                                      {3122, 1.115683}};// Lambda(-bar)
-
 [[maybe_unused]] static float GetMassByPdgId(PdgCode_t pid) {
   /* 100ZZZAAA0 */
   if (pid > 1000000000) {
     auto A = (pid % 10000) / 10;
     return A * 0.938f /* GeV */;
   }
-  auto it = MassMap.find(std::abs(pid));
-  if (it != MassMap.end()) {
-    return MassMap.find(std::abs(pid))->second;
-  } else {
-    //for not only print warning not to break all converters //TODO exeption
-    std::cout << "WARINING! Mass of " + std::to_string(pid) + " is not known" << std::endl;
-    //    throw std::runtime_error("Mass of " + std::to_string(pid) + " is not known");
-    return 0.f;
-  }
-  //TODO wtf??
-  //  auto db = TDatabasePDG::Instance();
-  //  auto particle = db->GetParticle(pid);
-  //
-  //  if (particle) {
-  //    return particle->Mass();
-  //  }
+  auto db = TDatabasePDG::Instance();
+  auto particle = db->GetParticle(pid);
+  if( !particle )
+    throw std::runtime_error( "Particle with PDG-code "+std::to_string(pid)+" not found" );
+  return particle->Mass();
 }
 
 namespace Exyz {


### PR DESCRIPTION
Get rid of the map of codes and masses, replaced by TDataBasePDG. 
Runtime error in case if the particle is not found.