### PR TITLE
Release 1.0 fix 57

### DIFF
--- a/core/Configuration.hpp
+++ b/core/Configuration.hpp
@@ -46,6 +46,27 @@ class Configuration : public TObject {
 
   void Print(Option_t* ="") const;
 
+  /**
+   * @brief Merge two configurations without reindexing of the branches
+   * @param other
+   */
+  void Merge(const Configuration& other) {
+    for (auto & other_branch : other.branches_) {
+      const auto other_id = other_branch.GetId();
+      const auto other_name = other_branch.GetName();
+      for (auto &local_branch : branches_) {
+        if (other_id == local_branch.GetId()) {
+          throw std::runtime_error("Configurations contain branches with the same id-s");
+        }
+        if (other_name == local_branch.GetName()) {
+          throw std::runtime_error("Configurations contain branches with the same names");
+        }
+      }
+      /// DO NOT REINDEX
+      branches_.emplace_back(other_branch);
+    }
+  }
+
  protected:
   std::string name_;
   std::vector<BranchConfig> branches_{};

--- a/core/Configuration.hpp
+++ b/core/Configuration.hpp
@@ -34,11 +34,17 @@ class Configuration : public TObject {
 
   [[nodiscard]] BranchConfig& GetBranchConfig(const std::string& name);
   [[nodiscard]] const BranchConfig& GetBranchConfig(const std::string& name) const;
-  [[nodiscard]] const BranchConfig& GetBranchConfig(Integer_t i) const { return branches_.at(i); }
+  [[nodiscard]] const BranchConfig& GetBranchConfig(Integer_t i) const {
+    for (auto & branch_config : branches_) {
+      if (branch_config.GetId() == i)
+        return branch_config;
+    }
+    throw std::runtime_error("Branch with id = " + std::to_string(i) + " not found");
+  }
   [[nodiscard]] const std::vector<BranchConfig>& GetBranchConfigs() const { return branches_; }
   [[nodiscard]] uint GetNumberOfBranches() const { return branches_.size(); }
 
-  [[nodiscard]] uint GetLastId() const { return branches_.empty() ? 0 : branches_.back().GetId(); }
+  [[nodiscard]] uint GetLastId() const { throw std::runtime_error("This function works not as expected"); }
 
   [[nodiscard]] const std::string& GetMatchName(const std::string& br1, const std::string& br2) const;
   [[nodiscard]] std::pair<std::string, bool> GetMatchInfo(const std::string& br1, const std::string& br2) const;

--- a/infra/TreeReader.hpp
+++ b/infra/TreeReader.hpp
@@ -76,10 +76,8 @@ static inline Configuration* GetConfigurationFromFileList(const std::vector<std:
   Configuration* config{GetObjectFromFileList<Configuration>(filelists.at(0), name)};
 
   for (uint i = 1; i < filelists.size(); ++i) {
-    auto* config_i = GetObjectFromFileList<Configuration>(filelists.at(i), name);
-    for (uint j = 0; j < config_i->GetNumberOfBranches(); ++j) {
-      config->AddBranchConfig(config_i->GetBranchConfig(j));
-    }
+    auto config_i = GetObjectFromFileList<Configuration>(filelists.at(i), name);
+    config->Merge(*config_i);
   }
   return config;
 }


### PR DESCRIPTION
After few tests no showstopping issues appeared.

AnalysisTree::Configuration::GetLastId is mocked with exception and should not be used anymore.