### PR TITLE
Hotfix 73

### DIFF
--- a/infra/Task.cpp
+++ b/infra/Task.cpp
@@ -9,7 +9,8 @@ ANALYSISTREE_ATTR_NODISCARD bool Task::IsGoodEvent(const Chain& t) const {
   // Here EventHeader expected
   //TODO throw exeption otherwise
   const auto cut = apply_cut(0, event_cuts_);
-  return ANALYSISTREE_UTILS_VISIT(cut, t.GetPointerToBranch(*br_name));
+  const auto data_ptr = t.GetPointerToBranch(*br_name);
+  return ANALYSISTREE_UTILS_VISIT(cut, data_ptr);
 }
 
 void Task::PreInit() {

--- a/infra/Task.cpp
+++ b/infra/Task.cpp
@@ -3,6 +3,14 @@
 
 namespace AnalysisTree {
 
+ANALYSISTREE_ATTR_NODISCARD bool Task::IsGoodEvent(const Chain& t) const {
+  if(!event_cuts_) return true;
+  auto br_name = event_cuts_->GetBranches().begin();
+  // Here EventHeader expected
+  //TODO throw exeption otherwise
+  return ANALYSISTREE_UTILS_VISIT(apply_cut(0, event_cuts_), t.GetPointerToBranch(*br_name));
+}
+
 void Task::PreInit() {
   const auto* const man = TaskManager::GetInstance();
   config_ = man->GetConfig();

--- a/infra/Task.cpp
+++ b/infra/Task.cpp
@@ -8,7 +8,8 @@ ANALYSISTREE_ATTR_NODISCARD bool Task::IsGoodEvent(const Chain& t) const {
   auto br_name = event_cuts_->GetBranches().begin();
   // Here EventHeader expected
   //TODO throw exeption otherwise
-  return ANALYSISTREE_UTILS_VISIT(apply_cut(0, event_cuts_), t.GetPointerToBranch(*br_name));
+  const auto cut = apply_cut(0, event_cuts_);
+  return ANALYSISTREE_UTILS_VISIT(cut, t.GetPointerToBranch(*br_name));
 }
 
 void Task::PreInit() {

--- a/infra/Task.hpp
+++ b/infra/Task.hpp
@@ -42,13 +42,7 @@ class Task {
     return event_cuts_ ? event_cuts_->Apply(event_header) : true;
   }
 
-  ANALYSISTREE_ATTR_NODISCARD bool IsGoodEvent(const Chain& t) const {
-    if(!event_cuts_) return true;
-    auto br_name = event_cuts_->GetBranches().begin();
-    // Here EventHeader expected
-    //TODO throw exeption otherwise
-    return ANALYSISTREE_UTILS_VISIT(apply_cut(0, event_cuts_), t.GetPointerToBranch(*br_name));
-  }
+  ANALYSISTREE_ATTR_NODISCARD bool IsGoodEvent(const Chain& t) const;
 
   void SetEventCuts(Cuts* cuts){
     if(cuts->GetBranches().size() != 1){


### PR DESCRIPTION
Task.{h,c}pp: `ANALYSISTREE_APPLY_VISITOR` moved from header to the implementation. Compatibility with old boost (v1.53) is restored. 