### PR TITLE
not try to rewrite EventHeader's id

### DIFF
--- a/core/EventHeader.hpp
+++ b/core/EventHeader.hpp
@@ -59,6 +59,7 @@ class EventHeader : public Container {
         case EventHeaderFields::kVertexX: vtx_pos_[Exyz::kX] = value; break;
         case EventHeaderFields::kVertexY: vtx_pos_[Exyz::kY] = value; break;
         case EventHeaderFields::kVertexZ: vtx_pos_[Exyz::kZ] = value; break;
+        case EventHeaderFields::kId: break;
         default: throw std::runtime_error("Invalid field id");
       }
     }


### PR DESCRIPTION
Avoid crash with id field when CopyContent() of EventHeader.