### PR TITLE
avoid . in branchname of plaintree

### DIFF
--- a/infra/PlainTreeFiller.cpp
+++ b/infra/PlainTreeFiller.cpp
@@ -1,6 +1,8 @@
 /* Copyright (C) 2019-2021 GSI, Universität Tübingen
    SPDX-License-Identifier: GPL-3.0-only
    Authors: Viktor Klochkov, Ilya Selyuzhenkov */
+#include <algorithm>
+
 #include "TTree.h"
 
 #include "PlainTreeFiller.hpp"
@@ -39,7 +41,8 @@ void PlainTreeFiller::Init() {
   plain_tree_ = new TTree(tree_name_.c_str(), "Plain Tree");
   for (size_t i = 0; i < vars.size(); ++i) {
     std::string leaf_name = vars[i].GetName();
-    plain_tree_->Branch(vars[i].GetName().c_str(), &(vars_.at(i)), Form("%s/F", leaf_name.c_str()));
+    std::replace(leaf_name.begin(), leaf_name.end(), '.', '_');
+    plain_tree_->Branch(leaf_name.c_str(), &(vars_.at(i)), Form("%s/F", leaf_name.c_str()));
   }
 }
 


### PR DESCRIPTION
There is a dot in branchname of AnalysisTree (what is correct according to ROOT officials), but when converting it to a plain tree it leads to problems with reading plain root tree with python. Therefore dot '.' in branchname was replaced with underscore '_'. (I am not sure that replacing is done in the best place, but it works).