### PR TITLE
adapt infra-1.0 to v2.2.7

### DIFF
--- a/infra-1.0/CMakeLists.txt
+++ b/infra-1.0/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND HEADERS
         Utils.hpp
         )
 
-include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../include)
 add_library(AnalysisTreeInfraVersion1 SHARED ${SOURCES} G__AnalysisTreeInfraVersion1.cxx)
 target_compile_definitions(AnalysisTreeInfraVersion1 PUBLIC
         $<$<BOOL:${Boost_FOUND}>:ANALYSISTREE_BOOST_FOUND>)


### PR DESCRIPTION
Find headers correctly after moving them from CMAKE_BINARY_DIR/include to CMAKE_CURRENT_BINARY_DIR (v2.2.6 - v2.2.7)