### PR TITLE
adapt infra-1.0 to v2.2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
 
 set(${PROJECT_NAME}_INCLUDE_DIR "include")
 set(${PROJECT_NAME}_LIBRARY_DIR "lib")
+set(${AnalysisTree_BINARY_DIR} "${CMAKE_CURRENT_BINARY_DIR}")
 
 configure_package_config_file(
         cmake/${PROJECT_NAME}Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake

--- a/infra-1.0/CMakeLists.txt
+++ b/infra-1.0/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND HEADERS
         Utils.hpp
         )
 
-include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../include)
 add_library(AnalysisTreeInfraVersion1 SHARED ${SOURCES} G__AnalysisTreeInfraVersion1.cxx)
 target_compile_definitions(AnalysisTreeInfraVersion1 PUBLIC
         $<$<BOOL:${Boost_FOUND}>:ANALYSISTREE_BOOST_FOUND>)


### PR DESCRIPTION
Create CMake variable with AnalysisTree build location (needed for packages depending on AnalysisTree).