### PR TITLE
fix bug with ignoring matchings in configs>0 in filelist

### DIFF
--- a/core/Configuration.cpp
+++ b/core/Configuration.cpp
@@ -111,11 +111,7 @@ std::pair<std::string, bool> Configuration::GetMatchInfo(const std::string& br1,
   }
 }
 
-void Configuration::AddMatch(Matching* match) {
-  assert(match);
-  const std::string br1 = GetBranchConfig(match->GetBranch1Id()).GetName();
-  const std::string br2 = GetBranchConfig(match->GetBranch2Id()).GetName();
-  const std::string data_branch = br1 + "2" + br2;
+void Configuration::AddMatch(const std::string& br1, const std::string& br2, const std::string& data_branch) {
   /* looking up for match with same branches */
   auto is_matching_exists = std::find_if(begin(matches_), end(matches_), [&br1, &br2](const MatchingConfig& config) -> bool {
                               return (br1 == config.GetFirstBranchName() && br2 == config.GetSecondBranchName()) || (br2 == config.GetFirstBranchName() && br1 == config.GetSecondBranchName());
@@ -130,6 +126,23 @@ void Configuration::AddMatch(Matching* match) {
   matches_.emplace_back(br1, br2, data_branch);
   /* refresh index */
   matches_index_ = MakeMatchingIndex(matches_);
+}
+
+void Configuration::AddMatch(Matching* match) {
+  assert(match);
+  const std::string br1 = GetBranchConfig(match->GetBranch1Id()).GetName();
+  const std::string br2 = GetBranchConfig(match->GetBranch2Id()).GetName();
+  const std::string data_branch = br1 + "2" + br2;
+
+  AddMatch(br1, br2, data_branch);
+}
+
+void Configuration::AddMatch(const MatchingConfig& matching_config) {
+  const std::string br1 = matching_config.GetFirstBranchName();
+  const std::string br2 = matching_config.GetSecondBranchName();
+  const std::string data_branch = matching_config.GetDataBranchName();
+
+  AddMatch(br1, br2, data_branch);
 }
 
 std::vector<std::string> Configuration::GetListOfBranches() const {

--- a/core/Configuration.hpp
+++ b/core/Configuration.hpp
@@ -77,6 +77,8 @@ class Configuration : public TObject {
 
   void AddMatch(Matching* match);
 
+  void AddMatch(const MatchingConfig& matching_config);
+
   ANALYSISTREE_ATTR_NODISCARD BranchConfig& GetBranchConfig(const std::string& name);
   ANALYSISTREE_ATTR_NODISCARD const BranchConfig& GetBranchConfig(const std::string& name) const;
   ANALYSISTREE_ATTR_NODISCARD const BranchConfig& GetBranchConfig(size_t i) const {
@@ -87,6 +89,7 @@ class Configuration : public TObject {
     return it->second;
   }
   ANALYSISTREE_ATTR_NODISCARD const std::map<size_t, BranchConfig>& GetBranchConfigs() const { return branches_; }
+  ANALYSISTREE_ATTR_NODISCARD const std::vector<MatchingConfig>& GetMatchingConfigs() const { return matches_; }
   ANALYSISTREE_ATTR_NODISCARD unsigned int GetNumberOfBranches() const { return branches_.size(); }
 
   ANALYSISTREE_ATTR_NODISCARD const std::string& GetMatchName(const std::string& br1, const std::string& br2) const;
@@ -147,6 +150,8 @@ class Configuration : public TObject {
   std::vector<MatchingConfig> matches_{};
 
   MatchingIndex matches_index_{};//! transient field in this version
+
+  void AddMatch(const std::string& br1, const std::string& br2, const std::string& data_branch);
 
   ClassDef(Configuration, 4)
 };

--- a/infra/Chain.cpp
+++ b/infra/Chain.cpp
@@ -125,6 +125,10 @@ void Chain::InitConfiguration() {
     for (const auto& c : config_i->GetBranchConfigs()) {
       configuration_->AddBranchConfig(c.second);
     }
+
+    for (const auto& c : config_i->GetMatchingConfigs()) {
+      configuration_->AddMatch(c);
+    }
   }
 }
 
@@ -153,7 +157,7 @@ T* Chain::GetObjectFromFileList(const std::string& filelist, const std::string& 
   }
 
   if (object == nullptr) {
-    throw std::runtime_error("AnalysisTree::GetObjectFromFileList - object is nullprt");
+    throw std::runtime_error("AnalysisTree::GetObjectFromFileList - object is nullptr");
   }
 
   return object;


### PR DESCRIPTION
When creating Chain from the vector of filelists, the resulting Configuration did not contain Matchings from all the files except of 0-th one. This bug was fixed.