### PR TITLE
Operate AT::Variable from >2 branches

### DIFF
--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -190,13 +190,14 @@ void AnalysisEntry::FillFromOneChannalizedBranch() {
     std::vector<std::pair<const Branch&, int>> vec_pairs;
     int i{0};
     for(const auto& br : branches_) {
+      int ch{-1};
       if(non_eve_header_indices_.at(0) == i) {
-        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, i_channel});
-        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, i_channel});
+        ch = i_channel;
       } else {
-        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, 0});
-        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, 0});
+        ch = 0;
       }
+      vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, ch});
+      vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, ch});
       i++;
     }
 
@@ -223,16 +224,16 @@ void AnalysisEntry::FillFromTwoChannalizedBranches() {
     std::vector<std::pair<const Branch&, int>> vec_pairs;
     int i{0};
     for(const auto& br : branches_) {
+      int ch{-1};
       if (non_eve_header_indices_.at(0) == i) {
-        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, match.first});
-        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, match.first});
+        ch = match.first;
       } else if (non_eve_header_indices_.at(1) == i) {
-        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, match.second});
-        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, match.second});
+        ch = match.second;
       } else {
-        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, 0});
-        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, 0});
+        ch = 0;
       }
+      vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, ch});
+      vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, ch});
       i++;
     }
 

--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -18,7 +18,8 @@ bool AnalysisEntry::ApplyCutOnBranches(std::vector<std::tuple<const Branch*, Cut
   for(auto& iv : input_vec) {
     if (std::get<1>(iv) && !std::get<1>(iv)->Apply((*std::get<0>(iv))[std::get<2>(iv)])) { return false; }
     BranchChannel bch = (*std::get<0>(iv))[std::get<2>(iv)];
-    cuts_vec.emplace_back((std::pair<const BranchChannel*, size_t>){&bch, std::get<0>(iv)->GetId()});
+    BranchChannel* bchptr = new BranchChannel(std::move(bch));
+    cuts_vec.emplace_back((std::pair<const BranchChannel*, size_t>){bchptr, std::get<0>(iv)->GetId()});
   }
   return !cuts_ || cuts_->Apply(cuts_vec);
 }
@@ -37,7 +38,8 @@ double AnalysisEntry::FillVariable(const Variable& var, std::vector<std::pair<co
   std::vector<std::pair<const BranchChannel*, size_t>> vec;
   for(auto& bi : b_id) {
     BranchChannel bch = (*bi.first)[bi.second];
-    vec.emplace_back((std::pair<const BranchChannel*, size_t>){&bch, bi.first->GetId()});
+    BranchChannel* bchptr = new BranchChannel(std::move(bch));
+    vec.emplace_back((std::pair<const BranchChannel*, size_t>){bchptr, bi.first->GetId()});
   }
   return var.GetValue(vec);
 }

--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -55,11 +55,6 @@ bool AnalysisEntry::ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, 
   return result;
 }
 
-// bool AnalysisEntry::ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const {
-//   std::vector<std::tuple<const Branch*, Cuts*, int>> vec = {{&br1, cuts1, ch1}, {&br2, cuts2, ch2}, {&br3, cuts3, ch3}};
-//   return ApplyCutOnBranches(vec);
-// }
-
 double AnalysisEntry::FillVariable(const Variable& var, std::vector<const Branch*>& br, std::vector<int>& id) {
   if(br.size() != id.size()) {
     throw std::runtime_error("AnalysisTree::AnalysisEntry::FillVariable() - Branch and Id vectors must have the same size");
@@ -91,102 +86,6 @@ double AnalysisEntry::FillVariable(const Variable& var, const Branch& br1, int c
   return result;
 }
 
-// double AnalysisEntry::FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3) {
-//   std::vector<std::pair<const Branch*, int>> vec = {{&br1, ch1}, {&br2, ch2}, {&br3, ch3}};
-//   return FillVariable(var, vec);
-// }
-
-///**
-// * @brief takes BranchReader and evaluates all Variables associated with branch.
-// * If a branch is a Channel or Tracking detector, evaluation is performed channel-by-channel.
-// * If channel or track fails to pass cuts it won't be written
-// */
-// void AnalysisEntry::FillFromOneBranch() {
-//   const auto& br = branches_.at(0).first;
-//
-//   const auto n_channels = br.size();
-//   values_.reserve(n_channels);
-//
-//   for (size_t i_channel = 0; i_channel < n_channels; ++i_channel) {
-//     if (!ApplyCutOnBranch(br, branches_.at(0).second, i_channel)) continue;
-//     std::vector<double> temp_vars(vars_.size());
-//     short i_var{0};
-//     for (const auto& var : vars_) {
-//       temp_vars[i_var] = var.GetValue(br[i_channel]);
-//       i_var++;
-//     }//variables
-//     values_.emplace_back(temp_vars);
-//   }//channels
-// }
-
-// void AnalysisEntry::FillMatchingForEventHeader(const Branch& br1, const Branch& br2) {
-//   matching_->Clear();
-//   for (size_t i = 0; i < br1.size(); ++i) {
-//     matching_->AddMatch(i, 0);
-//   }
-// }
-
-///**
-//* @brief FillFromTwoBranches populates Variables if matching between two branches is defined
-//* It iterates over registered matches and fills variables
-//*/
-// void AnalysisEntry::FillFromTwoBranches() {
-//   auto& br1 = branches_.at(0);
-//   auto& br2 = branches_.at(1);
-//   if (br1.first.GetBranchType() == DetType::kEventHeader) {//put EventHeader to second place, to be able to fill matching
-//     std::swap(br1, br2);
-//   }
-//   if (br2.first.GetBranchType() == DetType::kEventHeader) {
-//     FillMatchingForEventHeader(br1.first, br2.first);
-//   }
-//   values_.reserve(matching_->GetMatches().size());
-//
-//   for (auto match : matching_->GetMatches(is_inverted_matching_)) {
-//     const int ch1 = match.first;
-//     const int ch2 = match.second;
-//     if (!ApplyCutOnBranches(br1.first, br1.second, ch1, br2.first, br2.second, ch2)) continue;
-//     std::vector<double> temp_vars(vars_.size());
-//     short i_var{};
-//     for (const auto& var : vars_) {
-//       temp_vars[i_var] = FillVariable(var, br1.first, ch1, br2.first, ch2);
-//       i_var++;
-//     }//variables
-//     values_.emplace_back(temp_vars);
-//   }
-// }
-
-// void AnalysisEntry::FillFromThreeBranches() {
-//   auto& br1 = branches_.at(0);
-//   auto& br2 = branches_.at(1);
-//   auto& br3 = branches_.at(2);
-//   values_.reserve(matching_->GetMatches().size());
-//   int event_header_n  = -1;
-//   if(br1.first.GetBranchType() == DetType::kEventHeader) {
-//     event_header_n = 0;
-//   } else if(br2.first.GetBranchType() == DetType::kEventHeader) {
-//     event_header_n = 1;
-//   } else {
-//     event_header_n = 2;
-//   }
-//   const int non_event_header_1 = (2-event_header_n)/2;
-//   const int non_event_header_2 = (5-event_header_n)/2;
-//
-//   for (auto match : matching_->GetMatches(is_inverted_matching_)) {
-//     std::array<int, 3> ch;
-//     ch.at(non_event_header_1) = match.first;
-//     ch.at(non_event_header_2) = match.second;
-//     ch.at(event_header_n) = 0;
-//     if (!ApplyCutOnBranches(br1.first, br1.second, ch.at(0), br2.first, br2.second, ch.at(1), br3.first, br3.second, ch.at(2))) continue;
-//     std::vector<double> temp_vars(vars_.size());
-//     short i_var{};
-//     for (const auto& var : vars_) {
-//       temp_vars[i_var] = FillVariable(var, br1.first, ch.at(0), br2.first, ch.at(1), br3.first, ch.at(2));
-//       i_var++;
-//     }//variables
-//     values_.emplace_back(temp_vars);
-//   }
-// }
-
 void AnalysisEntry::FillValues() {
   values_.clear();
   if (non_eve_header_indices_.size() == 0) {
@@ -196,18 +95,11 @@ void AnalysisEntry::FillValues() {
   } else if (non_eve_header_indices_.size() == 2) {
     FillFromTwoChannalizedBranches();
   }
-//   values_.clear();
-//   if (branches_.size() == 1) {
-//     FillFromOneBranch();
-//   } else if (branches_.size() == 2) {
-//     FillFromTwoBranches();
-//   } else if (branches_.size() == 3) {
-//     FillFromThreeBranches();
-//   } else {
-//     throw std::runtime_error("AnalysisEntry::FillValues - branches_.size() is more than 3 or 0");
-//   }
 }
 
+/**
+* @brief FillFromEveHeaders populates Variables from event headers only
+*/
 void AnalysisEntry::FillFromEveHeaders() {
   std::vector<const Branch*> br_vec;
   std::vector<Cuts*> cuts_vec;
@@ -232,6 +124,10 @@ void AnalysisEntry::FillFromEveHeaders() {
   values_.emplace_back(temp_vars);
 }
 
+/**
+* @brief FillFromOneChannalizedBranch populates Variables from one channalized branch
+* and any number of event headers.
+*/
 void AnalysisEntry::FillFromOneChannalizedBranch() {
   const auto n_channels = branches_.at(non_eve_header_indices_.at(0)).first->size();
   values_.reserve(n_channels);
@@ -263,6 +159,11 @@ void AnalysisEntry::FillFromOneChannalizedBranch() {
   }// channels
 }
 
+/**
+* @brief FillFromTwoChannalizedBranches populates Variables from two channalized branches
+* and any number of event headers.
+* It iterates over registered matches and fills variables
+*/
 void AnalysisEntry::FillFromTwoChannalizedBranches() {
   if(matching_ == nullptr) {
     throw std::runtime_error("AnalysisEntry::FillFromTwoChannalizedBranches() - Matching between non-EventHeader branches must be set");

--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -50,108 +50,201 @@ double AnalysisEntry::FillVariable(const Variable& var, const Branch& br1, int c
   return FillVariable(var, vec);
 }
 
-/**
- * @brief takes BranchReader and evaluates all Variables associated with branch.
- * If a branch is a Channel or Tracking detector, evaluation is performed channel-by-channel.
- * If channel or track fails to pass cuts it won't be written
- */
-void AnalysisEntry::FillFromOneBranch() {
-  const auto& br = branches_.at(0).first;
+///**
+// * @brief takes BranchReader and evaluates all Variables associated with branch.
+// * If a branch is a Channel or Tracking detector, evaluation is performed channel-by-channel.
+// * If channel or track fails to pass cuts it won't be written
+// */
+// void AnalysisEntry::FillFromOneBranch() {
+//   const auto& br = branches_.at(0).first;
+//
+//   const auto n_channels = br.size();
+//   values_.reserve(n_channels);
+//
+//   for (size_t i_channel = 0; i_channel < n_channels; ++i_channel) {
+//     if (!ApplyCutOnBranch(br, branches_.at(0).second, i_channel)) continue;
+//     std::vector<double> temp_vars(vars_.size());
+//     short i_var{0};
+//     for (const auto& var : vars_) {
+//       temp_vars[i_var] = var.GetValue(br[i_channel]);
+//       i_var++;
+//     }//variables
+//     values_.emplace_back(temp_vars);
+//   }//channels
+// }
 
-  const auto n_channels = br.size();
-  values_.reserve(n_channels);
+// void AnalysisEntry::FillMatchingForEventHeader(const Branch& br1, const Branch& br2) {
+//   matching_->Clear();
+//   for (size_t i = 0; i < br1.size(); ++i) {
+//     matching_->AddMatch(i, 0);
+//   }
+// }
 
-  for (size_t i_channel = 0; i_channel < n_channels; ++i_channel) {
-    if (!ApplyCutOnBranch(br, branches_.at(0).second, i_channel)) continue;
-    std::vector<double> temp_vars(vars_.size());
-    short i_var{0};
-    for (const auto& var : vars_) {
-      temp_vars[i_var] = var.GetValue(br[i_channel]);
-      i_var++;
-    }//variables
-    values_.emplace_back(temp_vars);
-  }//channels
-}
+///**
+//* @brief FillFromTwoBranches populates Variables if matching between two branches is defined
+//* It iterates over registered matches and fills variables
+//*/
+// void AnalysisEntry::FillFromTwoBranches() {
+//   auto& br1 = branches_.at(0);
+//   auto& br2 = branches_.at(1);
+//   if (br1.first.GetBranchType() == DetType::kEventHeader) {//put EventHeader to second place, to be able to fill matching
+//     std::swap(br1, br2);
+//   }
+//   if (br2.first.GetBranchType() == DetType::kEventHeader) {
+//     FillMatchingForEventHeader(br1.first, br2.first);
+//   }
+//   values_.reserve(matching_->GetMatches().size());
+//
+//   for (auto match : matching_->GetMatches(is_inverted_matching_)) {
+//     const int ch1 = match.first;
+//     const int ch2 = match.second;
+//     if (!ApplyCutOnBranches(br1.first, br1.second, ch1, br2.first, br2.second, ch2)) continue;
+//     std::vector<double> temp_vars(vars_.size());
+//     short i_var{};
+//     for (const auto& var : vars_) {
+//       temp_vars[i_var] = FillVariable(var, br1.first, ch1, br2.first, ch2);
+//       i_var++;
+//     }//variables
+//     values_.emplace_back(temp_vars);
+//   }
+// }
 
-void AnalysisEntry::FillMatchingForEventHeader(const Branch& br1, const Branch& br2) {
-  matching_->Clear();
-  for (size_t i = 0; i < br1.size(); ++i) {
-    matching_->AddMatch(i, 0);
-  }
-}
-
-/**
- * @brief FillFromTwoBranches populates Variables if matching between two branches is defined
- * It iterates over registered matches and fills variables
- */
-void AnalysisEntry::FillFromTwoBranches() {
-  auto& br1 = branches_.at(0);
-  auto& br2 = branches_.at(1);
-  if (br1.first.GetBranchType() == DetType::kEventHeader) {//put EventHeader to second place, to be able to fill matching
-    std::swap(br1, br2);
-  }
-  if (br2.first.GetBranchType() == DetType::kEventHeader) {
-    FillMatchingForEventHeader(br1.first, br2.first);
-  }
-  values_.reserve(matching_->GetMatches().size());
-
-  for (auto match : matching_->GetMatches(is_inverted_matching_)) {
-    const int ch1 = match.first;
-    const int ch2 = match.second;
-    if (!ApplyCutOnBranches(br1.first, br1.second, ch1, br2.first, br2.second, ch2)) continue;
-    std::vector<double> temp_vars(vars_.size());
-    short i_var{};
-    for (const auto& var : vars_) {
-      temp_vars[i_var] = FillVariable(var, br1.first, ch1, br2.first, ch2);
-      i_var++;
-    }//variables
-    values_.emplace_back(temp_vars);
-  }
-}
-
-void AnalysisEntry::FillFromThreeBranches() {
-  auto& br1 = branches_.at(0);
-  auto& br2 = branches_.at(1);
-  auto& br3 = branches_.at(2);
-  values_.reserve(matching_->GetMatches().size());
-  int event_header_n  = -1;
-  if(br1.first.GetBranchType() == DetType::kEventHeader) {
-    event_header_n = 0;
-  } else if(br2.first.GetBranchType() == DetType::kEventHeader) {
-    event_header_n = 1;
-  } else {
-    event_header_n = 2;
-  }
-  const int non_event_header_1 = (2-event_header_n)/2;
-  const int non_event_header_2 = (5-event_header_n)/2;
-
-  for (auto match : matching_->GetMatches(is_inverted_matching_)) {
-    std::array<int, 3> ch;
-    ch.at(non_event_header_1) = match.first;
-    ch.at(non_event_header_2) = match.second;
-    ch.at(event_header_n) = 0;
-    if (!ApplyCutOnBranches(br1.first, br1.second, ch.at(0), br2.first, br2.second, ch.at(1), br3.first, br3.second, ch.at(2))) continue;
-    std::vector<double> temp_vars(vars_.size());
-    short i_var{};
-    for (const auto& var : vars_) {
-      temp_vars[i_var] = FillVariable(var, br1.first, ch.at(0), br2.first, ch.at(1), br3.first, ch.at(2));
-      i_var++;
-    }//variables
-    values_.emplace_back(temp_vars);
-  }
-}
+// void AnalysisEntry::FillFromThreeBranches() {
+//   auto& br1 = branches_.at(0);
+//   auto& br2 = branches_.at(1);
+//   auto& br3 = branches_.at(2);
+//   values_.reserve(matching_->GetMatches().size());
+//   int event_header_n  = -1;
+//   if(br1.first.GetBranchType() == DetType::kEventHeader) {
+//     event_header_n = 0;
+//   } else if(br2.first.GetBranchType() == DetType::kEventHeader) {
+//     event_header_n = 1;
+//   } else {
+//     event_header_n = 2;
+//   }
+//   const int non_event_header_1 = (2-event_header_n)/2;
+//   const int non_event_header_2 = (5-event_header_n)/2;
+//
+//   for (auto match : matching_->GetMatches(is_inverted_matching_)) {
+//     std::array<int, 3> ch;
+//     ch.at(non_event_header_1) = match.first;
+//     ch.at(non_event_header_2) = match.second;
+//     ch.at(event_header_n) = 0;
+//     if (!ApplyCutOnBranches(br1.first, br1.second, ch.at(0), br2.first, br2.second, ch.at(1), br3.first, br3.second, ch.at(2))) continue;
+//     std::vector<double> temp_vars(vars_.size());
+//     short i_var{};
+//     for (const auto& var : vars_) {
+//       temp_vars[i_var] = FillVariable(var, br1.first, ch.at(0), br2.first, ch.at(1), br3.first, ch.at(2));
+//       i_var++;
+//     }//variables
+//     values_.emplace_back(temp_vars);
+//   }
+// }
 
 void AnalysisEntry::FillValues() {
   values_.clear();
-  if (branches_.size() == 1) {
-    FillFromOneBranch();
-  } else if (branches_.size() == 2) {
-    FillFromTwoBranches();
-  } else if (branches_.size() == 3) {
-    FillFromThreeBranches();
-  } else {
-    throw std::runtime_error("AnalysisEntry::FillValues - branches_.size() is more than 3 or 0");
+  if (non_eve_header_indices_.size() == 0) {
+    FillFromEveHeaders();
+  } else if (non_eve_header_indices_.size() == 1) {
+    FillFromOneChannalizedBranch();
+  } else if (non_eve_header_indices_.size() == 2) {
+    FillFromTwoChannalizedBranches();
   }
+//   values_.clear();
+//   if (branches_.size() == 1) {
+//     FillFromOneBranch();
+//   } else if (branches_.size() == 2) {
+//     FillFromTwoBranches();
+//   } else if (branches_.size() == 3) {
+//     FillFromThreeBranches();
+//   } else {
+//     throw std::runtime_error("AnalysisEntry::FillValues - branches_.size() is more than 3 or 0");
+//   }
+}
+
+void AnalysisEntry::FillFromEveHeaders() {
+  std::vector<std::tuple<const Branch&, Cuts*, int>> vec_tuples;
+  std::vector<std::pair<const Branch&, int>> vec_pairs;
+  for(const auto& br : branches_) {
+    vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, 0});
+    vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, 0});
+  }
+
+  values_.reserve(1);
+  if (!ApplyCutOnBranches(vec_tuples)) return;
+  std::vector<double> temp_vars(vars_.size());
+  short i_var{0};
+  for (const auto& var : vars_) {
+    temp_vars[i_var] = FillVariable(var, vec_pairs);
+    i_var++;
+  }//variables
+  values_.emplace_back(temp_vars);
+}
+
+void AnalysisEntry::FillFromOneChannalizedBranch() {
+  const auto n_channels = branches_.at(non_eve_header_indices_.at(0)).first.size();
+  values_.reserve(n_channels);
+
+  for (size_t i_channel = 0; i_channel < n_channels; ++i_channel) {
+    std::vector<std::tuple<const Branch&, Cuts*, int>> vec_tuples;
+    std::vector<std::pair<const Branch&, int>> vec_pairs;
+    int i{0};
+    for(const auto& br : branches_) {
+      if(non_eve_header_indices_.at(0) == i) {
+        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, i_channel});
+        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, i_channel});
+      } else {
+        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, 0});
+        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, 0});
+      }
+      i++;
+    }
+
+    if (!ApplyCutOnBranches(vec_tuples)) continue;
+    std::vector<double> temp_vars(vars_.size());
+    short i_var{0};
+    for (const auto& var : vars_) {
+      temp_vars[i_var] = FillVariable(var, vec_pairs);
+      i_var++;
+    }//variables
+    values_.emplace_back(temp_vars);
+  }// channels
+}
+
+void AnalysisEntry::FillFromTwoChannalizedBranches() {
+  if(matching_ == nullptr) {
+    throw std::runtime_error("AnalysisEntry::FillFromTwoChannalizedBranches() - Matching between non-EventHeader branches must be set");
+  }
+
+  values_.reserve(matching_->GetMatches().size());
+
+  for (auto match : matching_->GetMatches(is_inverted_matching_)) {
+    std::vector<std::tuple<const Branch&, Cuts*, int>> vec_tuples;
+    std::vector<std::pair<const Branch&, int>> vec_pairs;
+    int i{0};
+    for(const auto& br : branches_) {
+      if (non_eve_header_indices_.at(0) == i) {
+        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, match.first});
+        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, match.first});
+      } else if (non_eve_header_indices_.at(1) == i) {
+        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, match.second});
+        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, match.second});
+      } else {
+        vec_tuples.emplace_back((std::tuple<const Branch&, Cuts*, int>){br.first, br.second, 0});
+        vec_pairs.emplace_back((std::pair<const Branch&, int>){br.first, 0});
+      }
+      i++;
+    }
+
+    if (!ApplyCutOnBranches(vec_tuples)) continue;
+    std::vector<double> temp_vars(vars_.size());
+    short i_var{0};
+    for (const auto& var : vars_) {
+      temp_vars[i_var] = FillVariable(var, vec_pairs);
+      i_var++;
+    }//variables
+    values_.emplace_back(temp_vars);
+  }// channels
 }
 
 void AnalysisEntry::FillBranchNames() {
@@ -173,41 +266,24 @@ void AnalysisEntry::Init(const Configuration& conf, const std::map<std::string, 
     var.Init(conf);
   }
 
-  if (branch_names_.size() == 2) {
-    auto det1_type = conf.GetBranchConfig(*branch_names_.begin()).GetType();
-    auto det2_type = conf.GetBranchConfig(*std::next(branch_names_.begin(), 1)).GetType();
-
-    if (det1_type != DetType::kEventHeader && det2_type != DetType::kEventHeader) {
-      auto match_info = conf.GetMatchInfo(*branch_names_.begin(), *std::next(branch_names_.begin(), 1));
-      SetIsInvertedMatching(match_info.second);
-      SetMatching((Matching*) matches.find(match_info.first)->second);
+  int i{0};
+  for(auto& bn : branch_names_) {
+    if(conf.GetBranchConfig(bn).GetType() == DetType::kEventHeader) {
+      eve_header_indices_.push_back(i);
     } else {
-      if (det1_type == DetType::kEventHeader) {
-        matching_ = new Matching(branches_.at(1).first.GetId(), branches_.at(0).first.GetId());
-      } else {
-        matching_ = new Matching(branches_.at(0).first.GetId(), branches_.at(1).first.GetId());
-      }
+      non_eve_header_indices_.push_back(i);
     }
-  } else if (branch_names_.size() > 2) {
-    std::array<DetType, 3> det_type;
-    det_type.at(0) = conf.GetBranchConfig(*branch_names_.begin()).GetType();
-    det_type.at(1) = conf.GetBranchConfig(*std::next(branch_names_.begin(), 1)).GetType();
-    det_type.at(2) = conf.GetBranchConfig(*std::next(branch_names_.begin(), 2)).GetType();
+    i++;
+  }
+  if(branch_names_.size() == 0) {
+    throw std::runtime_error("AnalysisEntry::Init() - at least 1 branch is needed");
+  }
+  if(non_eve_header_indices_.size() > 2) {
+    throw std::runtime_error("AnalysisEntry::Init() - 2 non-EventHeader branches are allowed as maximum");
+  }
 
-    int n_event_headers=0;
-    int event_header_n=-1;
-    for(int i=0; i<3; i++) {
-      if(det_type.at(i) == DetType::kEventHeader) {
-        n_event_headers++;
-        event_header_n = i;
-      }
-    }
-    if(n_event_headers != 1) {
-      throw std::runtime_error("AnalysisEntry::Init() - among 3 branches 1 and only 1 must be EventHeader");
-    }
-    const int non_event_header_1 = (2-event_header_n)/2;
-    const int non_event_header_2 = (5-event_header_n)/2;
-    auto match_info = conf.GetMatchInfo(*std::next(branch_names_.begin(), non_event_header_1), *std::next(branch_names_.begin(), non_event_header_2));
+  if(non_eve_header_indices_.size() == 2) {
+    auto match_info = conf.GetMatchInfo(*std::next(branch_names_.begin(), non_eve_header_indices_.at(0)), *std::next(branch_names_.begin(), non_eve_header_indices_.at(1)));
     SetIsInvertedMatching(match_info.second);
     SetMatching((Matching*) matches.find(match_info.first)->second);
   }

--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -26,11 +26,11 @@ bool AnalysisEntry::ApplyCutOnBranches(std::vector<const Branch*>& br, std::vect
     bch_vec.emplace_back(bchptr);
     id_vec.emplace_back(br.at(i)->GetId());
   }
-
-  for(auto& b : br) {
-    delete b;
+  bool result = !cuts_ || cuts_->Apply(bch_vec, id_vec);
+  for(auto& bv : bch_vec) {
+    delete bv;
   }
-  return !cuts_ || cuts_->Apply(bch_vec, id_vec);
+  return result;
 }
 
 bool AnalysisEntry::ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const {
@@ -39,7 +39,10 @@ bool AnalysisEntry::ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, 
   std::vector<const Branch*> br_vec{br1_ptr, br2_ptr};
   std::vector<Cuts*> cuts_vec{cuts1, cuts2};
   std::vector<int> ch_vec{ch1, ch2};
-  return ApplyCutOnBranches(br_vec, cuts_vec, ch_vec);
+  bool result = ApplyCutOnBranches(br_vec, cuts_vec, ch_vec);
+  delete br1_ptr;
+  delete br2_ptr;
+  return result;
 }
 
 // bool AnalysisEntry::ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const {
@@ -59,11 +62,11 @@ double AnalysisEntry::FillVariable(const Variable& var, std::vector<const Branch
     bch_vec.emplace_back(bchptr);
     id_vec.emplace_back(br.at(i)->GetId());
   }
-
-  for(auto& b : br) {
-    delete b;
+  double result = var.GetValue(bch_vec, id_vec);
+  for(auto& bv : bch_vec) {
+    delete bv;
   }
-  return var.GetValue(bch_vec, id_vec);
+  return result;
 }
 
 double AnalysisEntry::FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2) {
@@ -71,7 +74,10 @@ double AnalysisEntry::FillVariable(const Variable& var, const Branch& br1, int c
   Branch* br2_ptr = new Branch(std::move(br2));
   std::vector<const Branch*> br_vec{br1_ptr, br2_ptr};
   std::vector<int> ch_vec{ch1, ch2};
-  return FillVariable(var, br_vec, ch_vec);
+  double result = FillVariable(var, br_vec, ch_vec);
+  delete br1_ptr;
+  delete br2_ptr;
+  return result;
 }
 
 // double AnalysisEntry::FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3) {
@@ -211,6 +217,9 @@ void AnalysisEntry::FillFromEveHeaders() {
     i_var++;
   }//variables
   values_.emplace_back(temp_vars);
+  for(auto& bv : br_vec) {
+    delete bv;
+  }
 }
 
 void AnalysisEntry::FillFromOneChannalizedBranch() {
@@ -244,6 +253,9 @@ void AnalysisEntry::FillFromOneChannalizedBranch() {
       i_var++;
     }//variables
     values_.emplace_back(temp_vars);
+    for(auto& bv : br_vec) {
+      delete bv;
+    }
   }// channels
 }
 
@@ -283,6 +295,9 @@ void AnalysisEntry::FillFromTwoChannalizedBranches() {
       i_var++;
     }//variables
     values_.emplace_back(temp_vars);
+    for(auto& bv : br_vec) {
+      delete bv;
+    }
   }// channels
 }
 

--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -233,28 +233,23 @@ void AnalysisEntry::FillFromOneChannalizedBranch() {
   const auto n_channels = branches_.at(non_eve_header_indices_.at(0)).first.size();
   values_.reserve(n_channels);
 
-  for (size_t i_channel = 0; i_channel < n_channels; ++i_channel) {
-    std::vector<const Branch*> br_vec;
-    std::vector<Cuts*> cuts_vec;
-    std::vector<int> id_vec;
-    br_vec.reserve(branches_.size());
-    cuts_vec.reserve(branches_.size());
-    id_vec.reserve(branches_.size());
-    int i{0};
-    for(const auto& br : branches_) {
-      int ch{-1};
-      if(non_eve_header_indices_.at(0) == i) {
-        ch = i_channel;
-      } else {
-        ch = 0;
-      }
-      Branch* br_ptr = new Branch(std::move(br.first));
-      br_vec.emplace_back(br_ptr);
-      cuts_vec.emplace_back(br.second);
-      id_vec.emplace_back(ch);
-      i++;
-    }
+  std::vector<const Branch*> br_vec;
+  std::vector<Cuts*> cuts_vec;
+  std::vector<int> id_vec;
+  br_vec.reserve(branches_.size());
+  cuts_vec.reserve(branches_.size());
+  id_vec.resize(branches_.size());
+  for(const auto& br : branches_) {
+    Branch* br_ptr = new Branch(std::move(br.first));
+    br_vec.emplace_back(br_ptr);
+    cuts_vec.emplace_back(br.second);
+  }
+  for(auto& ehi : eve_header_indices_) {
+    id_vec.at(ehi) = 0;
+  }
 
+  for (size_t i_channel = 0; i_channel < n_channels; ++i_channel) {
+    id_vec.at(non_eve_header_indices_.at(0)) = i_channel;
     if (!ApplyCutOnBranches(br_vec, cuts_vec, id_vec)) continue;
     std::vector<double> temp_vars(vars_.size());
     short i_var{0};
@@ -263,10 +258,10 @@ void AnalysisEntry::FillFromOneChannalizedBranch() {
       i_var++;
     }//variables
     values_.emplace_back(temp_vars);
-    for(auto& bv : br_vec) {
-      delete bv;
-    }
   }// channels
+  for(auto& bv : br_vec) {
+    delete bv;
+  }
 }
 
 void AnalysisEntry::FillFromTwoChannalizedBranches() {
@@ -276,29 +271,24 @@ void AnalysisEntry::FillFromTwoChannalizedBranches() {
 
   values_.reserve(matching_->GetMatches().size());
 
+  std::vector<const Branch*> br_vec;
+  std::vector<Cuts*> cuts_vec;
+  std::vector<int> id_vec;
+  br_vec.reserve(branches_.size());
+  cuts_vec.reserve(branches_.size());
+  id_vec.resize(branches_.size());
+  for(const auto& br : branches_) {
+    Branch* br_ptr = new Branch(std::move(br.first));
+    br_vec.emplace_back(br_ptr);
+    cuts_vec.emplace_back(br.second);
+  }
+  for(auto& ehi : eve_header_indices_) {
+    id_vec.at(ehi) = 0;
+  }
+
   for (auto match : matching_->GetMatches(is_inverted_matching_)) {
-    std::vector<const Branch*> br_vec;
-    std::vector<Cuts*> cuts_vec;
-    std::vector<int> id_vec;
-    br_vec.reserve(branches_.size());
-    cuts_vec.reserve(branches_.size());
-    id_vec.reserve(branches_.size());
-    int i{0};
-    for(const auto& br : branches_) {
-      int ch{-1};
-      if (non_eve_header_indices_.at(0) == i) {
-        ch = match.first;
-      } else if (non_eve_header_indices_.at(1) == i) {
-        ch = match.second;
-      } else {
-        ch = 0;
-      }
-      Branch* br_ptr = new Branch(std::move(br.first));
-      br_vec.emplace_back(br_ptr);
-      cuts_vec.emplace_back(br.second);
-      id_vec.emplace_back(ch);
-      i++;
-    }
+    id_vec.at(non_eve_header_indices_.at(0)) = match.first;
+    id_vec.at(non_eve_header_indices_.at(1)) = match.second;
 
     if (!ApplyCutOnBranches(br_vec, cuts_vec, id_vec)) continue;
     std::vector<double> temp_vars(vars_.size());
@@ -308,10 +298,10 @@ void AnalysisEntry::FillFromTwoChannalizedBranches() {
       i_var++;
     }//variables
     values_.emplace_back(temp_vars);
-    for(auto& bv : br_vec) {
-      delete bv;
-    }
   }// channels
+  for(auto& bv : br_vec) {
+    delete bv;
+  }
 }
 
 void AnalysisEntry::FillBranchNames() {

--- a/infra/AnalysisEntry.cpp
+++ b/infra/AnalysisEntry.cpp
@@ -19,6 +19,8 @@ bool AnalysisEntry::ApplyCutOnBranches(std::vector<const Branch*>& br, std::vect
   }
   std::vector<const BranchChannel*> bch_vec;
   std::vector<size_t> id_vec;
+  bch_vec.reserve(br.size());
+  id_vec.reserve(br.size());
   for(int i=0; i<br.size(); i++) {
     BranchChannel bch = (*br.at(i))[ch.at(i)];
     if(cuts.at(i) && !cuts.at(i)->Apply(bch)) { return false; }
@@ -56,6 +58,8 @@ double AnalysisEntry::FillVariable(const Variable& var, std::vector<const Branch
   }
   std::vector<const BranchChannel*> bch_vec;
   std::vector<size_t> id_vec;
+  bch_vec.reserve(br.size());
+  id_vec.reserve(br.size());
   for(int i=0; i<br.size(); i++) {
     BranchChannel bch = (*br.at(i))[id.at(i)];
     BranchChannel* bchptr = new BranchChannel(std::move(bch));
@@ -201,6 +205,9 @@ void AnalysisEntry::FillFromEveHeaders() {
   std::vector<const Branch*> br_vec;
   std::vector<Cuts*> cuts_vec;
   std::vector<int> id_vec;
+  br_vec.reserve(branches_.size());
+  cuts_vec.reserve(branches_.size());
+  id_vec.reserve(branches_.size());
   for(const auto& br : branches_) {
     Branch* br_ptr = new Branch(std::move(br.first));
     br_vec.emplace_back(br_ptr);
@@ -230,6 +237,9 @@ void AnalysisEntry::FillFromOneChannalizedBranch() {
     std::vector<const Branch*> br_vec;
     std::vector<Cuts*> cuts_vec;
     std::vector<int> id_vec;
+    br_vec.reserve(branches_.size());
+    cuts_vec.reserve(branches_.size());
+    id_vec.reserve(branches_.size());
     int i{0};
     for(const auto& br : branches_) {
       int ch{-1};
@@ -270,6 +280,9 @@ void AnalysisEntry::FillFromTwoChannalizedBranches() {
     std::vector<const Branch*> br_vec;
     std::vector<Cuts*> cuts_vec;
     std::vector<int> id_vec;
+    br_vec.reserve(branches_.size());
+    cuts_vec.reserve(branches_.size());
+    id_vec.reserve(branches_.size());
     int i{0};
     for(const auto& br : branches_) {
       int ch{-1};

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -54,10 +54,12 @@ class AnalysisEntry {
   void FillFromThreeBranches();
   void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranch(const Branch& br, Cuts* cuts, int i_channel) const;
-  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
-  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
-  static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2);
-  static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
+  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<std::tuple<const Branch&, Cuts*, int>>& input_vec) const;
+  [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
+  [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
+  static double FillVariable(const Variable& var, std::vector<std::pair<const Branch&, int>>& b_id);
+  [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2);
+  [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
 
   std::vector<Variable> vars_{};
   Cuts* cuts_{nullptr};///< non-owning

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -49,20 +49,14 @@ class AnalysisEntry {
   void FillBranchNames();
 
  private:
-//   void FillFromOneBranch();
-//   void FillFromTwoBranches();
-//   void FillFromThreeBranches();
   void FillFromEveHeaders();
   void FillFromOneChannalizedBranch();
   void FillFromTwoChannalizedBranches();
-//   void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranch(const Branch& br, Cuts* cuts, int i_channel) const;
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<const Branch*>& br, std::vector<Cuts*>& cuts, std::vector<int>& ch) const;
   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
-//   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
   static double FillVariable(const Variable& var, std::vector<const Branch*>& br, std::vector<int>& id);
   [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2);
-//   [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
 
   std::vector<Variable> vars_{};
   Cuts* cuts_{nullptr};///< non-owning

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -49,10 +49,13 @@ class AnalysisEntry {
   void FillBranchNames();
 
  private:
-  void FillFromOneBranch();
-  void FillFromTwoBranches();
-  void FillFromThreeBranches();
-  void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
+//   void FillFromOneBranch();
+//   void FillFromTwoBranches();
+//   void FillFromThreeBranches();
+  void FillFromEveHeaders();
+  void FillFromOneChannalizedBranch();
+  void FillFromTwoChannalizedBranches();
+//   void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranch(const Branch& br, Cuts* cuts, int i_channel) const;
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<std::tuple<const Branch&, Cuts*, int>>& input_vec) const;
   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
@@ -66,6 +69,9 @@ class AnalysisEntry {
 
   std::set<std::string> branch_names_{};
   std::vector<std::pair<Branch, Cuts*>> branches_{};///< non-owning pointers
+
+  std::vector<int> eve_header_indices_{};
+  std::vector<int> non_eve_header_indices_{};
 
   Matching* matching_{nullptr};///< non-owning
   bool is_inverted_matching_{false};

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -23,7 +23,7 @@ class AnalysisEntry {
 
  public:
   AnalysisEntry() = default;
-  virtual ~AnalysisEntry() = default;
+  virtual ~AnalysisEntry();
 
   explicit AnalysisEntry(std::vector<Variable> vars, Cuts* cuts = nullptr) : vars_(std::move(vars)),
                                                                              cuts_(cuts) {
@@ -43,7 +43,7 @@ class AnalysisEntry {
   ANALYSISTREE_ATTR_NODISCARD const std::vector<Variable>& GetVariables() const { return vars_; }
   ANALYSISTREE_ATTR_NODISCARD std::vector<Variable>& Variables() { return vars_; }
 
-  void AddBranch(const Branch& branch, Cuts* cuts = nullptr) { branches_.emplace_back(branch, cuts); }
+  void AddBranch(const Branch& branch, Cuts* cuts = nullptr);
   void SetMatching(Matching* matching) { matching_ = matching; }
   void SetIsInvertedMatching(bool is_inverted_matching) { is_inverted_matching_ = is_inverted_matching; }
   void FillBranchNames();
@@ -68,7 +68,7 @@ class AnalysisEntry {
   Cuts* cuts_{nullptr};///< non-owning
 
   std::set<std::string> branch_names_{};
-  std::vector<std::pair<Branch, Cuts*>> branches_{};///< non-owning pointers
+  std::vector<std::pair<const Branch*, Cuts*>> branches_{};///< non-owning pointers
 
   std::vector<int> eve_header_indices_{};
   std::vector<int> non_eve_header_indices_{};

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -51,10 +51,13 @@ class AnalysisEntry {
  private:
   void FillFromOneBranch();
   void FillFromTwoBranches();
+  void FillFromThreeBranches();
   void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranch(const Branch& br, Cuts* cuts, int i_channel) const;
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
+  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
   static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2);
+  static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
 
   std::vector<Variable> vars_{};
   Cuts* cuts_{nullptr};///< non-owning

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -57,10 +57,10 @@ class AnalysisEntry {
   void FillFromTwoChannalizedBranches();
 //   void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranch(const Branch& br, Cuts* cuts, int i_channel) const;
-  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<std::tuple<const Branch&, Cuts*, int>>& input_vec) const;
+  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<std::tuple<const Branch*, Cuts*, int>>& input_vec) const;
   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
-  static double FillVariable(const Variable& var, std::vector<std::pair<const Branch&, int>>& b_id);
+  static double FillVariable(const Variable& var, std::vector<std::pair<const Branch*, int>>& b_id);
   [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2);
   [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
 

--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -57,12 +57,12 @@ class AnalysisEntry {
   void FillFromTwoChannalizedBranches();
 //   void FillMatchingForEventHeader(const Branch& br1, const Branch& br2);
   ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranch(const Branch& br, Cuts* cuts, int i_channel) const;
-  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<std::tuple<const Branch*, Cuts*, int>>& input_vec) const;
+  ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(std::vector<const Branch*>& br, std::vector<Cuts*>& cuts, std::vector<int>& ch) const;
   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2) const;
-  [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
-  static double FillVariable(const Variable& var, std::vector<std::pair<const Branch*, int>>& b_id);
+//   [[deprecated]] ANALYSISTREE_ATTR_NODISCARD bool ApplyCutOnBranches(const Branch& br1, Cuts* cuts1, int ch1, const Branch& br2, Cuts* cuts2, int ch2, const Branch& br3, Cuts* cuts3, int ch3) const;
+  static double FillVariable(const Variable& var, std::vector<const Branch*>& br, std::vector<int>& id);
   [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2);
-  [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
+//   [[deprecated]] static double FillVariable(const Variable& var, const Branch& br1, int ch1, const Branch& br2, int ch2, const Branch& br3, int ch3);
 
   std::vector<Variable> vars_{};
   Cuts* cuts_{nullptr};///< non-owning

--- a/infra/BranchChannel.hpp
+++ b/infra/BranchChannel.hpp
@@ -12,6 +12,7 @@
 
 namespace AnalysisTree {
 
+class AnalysisEntry;
 class Branch;
 class Field;
 
@@ -49,6 +50,7 @@ class BranchChannel {
 
  private:
   friend Branch;
+  friend AnalysisEntry;
 
   BranchChannel(const Branch* branch, std::size_t i_channel);
   void UpdatePointer();

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -66,11 +66,6 @@ bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, si
   return result;
 }
 
-// bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-//   std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
-//   return Apply(vec);
-// }
-
 bool Cuts::Apply(const BranchChannel& ob) const {
   if (!is_init_) {
     throw std::runtime_error("Cuts::Apply - cut is not initialized!!");

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -52,6 +52,17 @@ bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, si
   return true;
 }
 
+bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
+  if (!is_init_) {
+    throw std::runtime_error("Cuts::Apply - cut is not initialized!!");
+  }
+  for (const auto& cut : cuts_) {
+    if (!cut.Apply(a, a_id, b, b_id, c, c_id))
+      return false;
+  }
+  return true;
+}
+
 bool Cuts::Apply(const BranchChannel& ob) const {
   if (!is_init_) {
     throw std::runtime_error("Cuts::Apply - cut is not initialized!!");

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -40,27 +40,33 @@ bool Cuts::Equal(const Cuts* that, const Cuts* other) {
   return false;
 }
 
-bool Cuts::Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const {
+bool Cuts::Apply(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const {
   if (!is_init_) {
     throw std::runtime_error("Cuts::Apply - cut is not initialized!!");
   }
+  if(bch.size() != id.size()) {
+    throw std::runtime_error("AnalysisTree::Cuts::Apply() - BranchChannel and Id vectors must have the same size");
+  }
   //    std::all_of(cuts_.begin(), cuts_.end(), Apply(a, a_id, b, b_id)); //TODO
   for (const auto& cut : cuts_) {
-    if (!cut.Apply(bch_id))
+    if (!cut.Apply(bch, id))
       return false;
   }
   return true;
 }
 
 bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
-  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}};
-  return Apply(vec);
+  BranchChannel* a_ptr = new BranchChannel(std::move(a));
+  BranchChannel* b_ptr = new BranchChannel(std::move(b));
+  std::vector<const BranchChannel*> brch_vec{a_ptr, b_ptr};
+  std::vector<size_t> id_vec{a_id, b_id};
+  return Apply(brch_vec, id_vec);
 }
 
-bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
-  return Apply(vec);
-}
+// bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
+//   std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
+//   return Apply(vec);
+// }
 
 bool Cuts::Apply(const BranchChannel& ob) const {
   if (!is_init_) {

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -40,27 +40,26 @@ bool Cuts::Equal(const Cuts* that, const Cuts* other) {
   return false;
 }
 
-bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
+bool Cuts::Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const {
   if (!is_init_) {
     throw std::runtime_error("Cuts::Apply - cut is not initialized!!");
   }
   //    std::all_of(cuts_.begin(), cuts_.end(), Apply(a, a_id, b, b_id)); //TODO
   for (const auto& cut : cuts_) {
-    if (!cut.Apply(a, a_id, b, b_id))
+    if (!cut.Apply(bch_id))
       return false;
   }
   return true;
 }
 
+bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
+  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}};
+  return Apply(vec);
+}
+
 bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  if (!is_init_) {
-    throw std::runtime_error("Cuts::Apply - cut is not initialized!!");
-  }
-  for (const auto& cut : cuts_) {
-    if (!cut.Apply(a, a_id, b, b_id, c, c_id))
-      return false;
-  }
-  return true;
+  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}, {c, c_id}};
+  return Apply(vec);
 }
 
 bool Cuts::Apply(const BranchChannel& ob) const {

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -40,7 +40,7 @@ bool Cuts::Equal(const Cuts* that, const Cuts* other) {
   return false;
 }
 
-bool Cuts::Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const {
+bool Cuts::Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const {
   if (!is_init_) {
     throw std::runtime_error("Cuts::Apply - cut is not initialized!!");
   }
@@ -53,12 +53,12 @@ bool Cuts::Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) c
 }
 
 bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
-  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}};
+  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}};
   return Apply(vec);
 }
 
 bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}, {c, c_id}};
+  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
   return Apply(vec);
 }
 

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -60,7 +60,10 @@ bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, si
   BranchChannel* b_ptr = new BranchChannel(std::move(b));
   std::vector<const BranchChannel*> brch_vec{a_ptr, b_ptr};
   std::vector<size_t> id_vec{a_id, b_id};
-  return Apply(brch_vec, id_vec);
+  bool result = Apply(brch_vec, id_vec);
+  delete a_ptr;
+  delete b_ptr;
+  return result;
 }
 
 // bool Cuts::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -69,6 +69,7 @@ class Cuts {
   bool Apply(const BranchChannel& ob) const;
 
   bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
+  bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Init(const Configuration& conf);
   void Print() const;

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -70,7 +70,6 @@ class Cuts {
 
   bool Apply(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-//   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Init(const Configuration& conf);
   void Print() const;

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -68,9 +68,9 @@ class Cuts {
 
   bool Apply(const BranchChannel& ob) const;
 
-  bool Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const;
+  bool Apply(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-  [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
+//   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Init(const Configuration& conf);
   void Print() const;

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -68,8 +68,9 @@ class Cuts {
 
   bool Apply(const BranchChannel& ob) const;
 
-  bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-  bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
+  bool Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const;
+  [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
+  [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Init(const Configuration& conf);
   void Print() const;

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -68,7 +68,7 @@ class Cuts {
 
   bool Apply(const BranchChannel& ob) const;
 
-  bool Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const;
+  bool Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 

--- a/infra/SimpleCut.cpp
+++ b/infra/SimpleCut.cpp
@@ -53,24 +53,30 @@ SimpleCut::SimpleCut(const Variable& var, double min, double max, std::string ti
   FillBranchNames();
 }
 
-bool SimpleCut::Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const {
+bool SimpleCut::Apply(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const {
+  if(bch.size() != id.size()) {
+    throw std::runtime_error("AnalysisTree::SimpleCut::Apply() - BranchChannel and Id vectors must have the same size");
+  }
   std::vector<double> variables;
   variables.reserve(vars_.size());
   for (const auto& var : vars_) {
-    variables.emplace_back(var.GetValue(bch_id));
+    variables.emplace_back(var.GetValue(bch, id));
   }
   return lambda_(variables);
 }
 
 bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
-  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}};
-  return Apply(vec);
+  BranchChannel* a_ptr = new BranchChannel(std::move(a));
+  BranchChannel* b_ptr = new BranchChannel(std::move(b));
+  std::vector<const BranchChannel*> brch_vec{a_ptr, b_ptr};
+  std::vector<size_t> id_vec{a_id, b_id};
+  return Apply(brch_vec, id_vec);
 }
 
-bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
-  return Apply(vec);
-}
+// bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
+//   std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
+//   return Apply(vec);
+// }
 
 bool SimpleCut::Apply(const BranchChannel& object) const {
   std::vector<double> variables;

--- a/infra/SimpleCut.cpp
+++ b/infra/SimpleCut.cpp
@@ -70,7 +70,10 @@ bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& 
   BranchChannel* b_ptr = new BranchChannel(std::move(b));
   std::vector<const BranchChannel*> brch_vec{a_ptr, b_ptr};
   std::vector<size_t> id_vec{a_id, b_id};
-  return Apply(brch_vec, id_vec);
+  bool result = Apply(brch_vec, id_vec);
+  delete a_ptr;
+  delete b_ptr;
+  return result;
 }
 
 // bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {

--- a/infra/SimpleCut.cpp
+++ b/infra/SimpleCut.cpp
@@ -62,6 +62,15 @@ bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& 
   return lambda_(variables);
 }
 
+bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
+  std::vector<double> variables;
+  variables.reserve(vars_.size());
+  for (const auto& var : vars_) {
+    variables.emplace_back(var.GetValue(a, a_id, b, b_id, c, c_id));
+  }
+  return lambda_(variables);
+}
+
 bool SimpleCut::Apply(const BranchChannel& object) const {
   std::vector<double> variables;
   variables.reserve(vars_.size());

--- a/infra/SimpleCut.cpp
+++ b/infra/SimpleCut.cpp
@@ -76,11 +76,6 @@ bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& 
   return result;
 }
 
-// bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-//   std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
-//   return Apply(vec);
-// }
-
 bool SimpleCut::Apply(const BranchChannel& object) const {
   std::vector<double> variables;
   variables.reserve(vars_.size());

--- a/infra/SimpleCut.cpp
+++ b/infra/SimpleCut.cpp
@@ -53,7 +53,7 @@ SimpleCut::SimpleCut(const Variable& var, double min, double max, std::string ti
   FillBranchNames();
 }
 
-bool SimpleCut::Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const {
+bool SimpleCut::Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const {
   std::vector<double> variables;
   variables.reserve(vars_.size());
   for (const auto& var : vars_) {
@@ -63,12 +63,12 @@ bool SimpleCut::Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_
 }
 
 bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
-  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}};
+  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}};
   return Apply(vec);
 }
 
 bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}, {c, c_id}};
+  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
   return Apply(vec);
 }
 

--- a/infra/SimpleCut.cpp
+++ b/infra/SimpleCut.cpp
@@ -53,22 +53,23 @@ SimpleCut::SimpleCut(const Variable& var, double min, double max, std::string ti
   FillBranchNames();
 }
 
-bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
+bool SimpleCut::Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const {
   std::vector<double> variables;
   variables.reserve(vars_.size());
   for (const auto& var : vars_) {
-    variables.emplace_back(var.GetValue(a, a_id, b, b_id));
+    variables.emplace_back(var.GetValue(bch_id));
   }
   return lambda_(variables);
 }
 
+bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
+  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}};
+  return Apply(vec);
+}
+
 bool SimpleCut::Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  std::vector<double> variables;
-  variables.reserve(vars_.size());
-  for (const auto& var : vars_) {
-    variables.emplace_back(var.GetValue(a, a_id, b, b_id, c, c_id));
-  }
-  return lambda_(variables);
+  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}, {c, c_id}};
+  return Apply(vec);
 }
 
 bool SimpleCut::Apply(const BranchChannel& object) const {

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -91,7 +91,6 @@ class SimpleCut {
   bool Apply(const BranchChannel& object) const;
   bool Apply(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-//   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Print() const;
 

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -89,9 +89,9 @@ class SimpleCut {
     return lambda_(variables);
   }
   bool Apply(const BranchChannel& object) const;
-  bool Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const;
+  bool Apply(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-  [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
+//   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Print() const;
 

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -89,8 +89,9 @@ class SimpleCut {
     return lambda_(variables);
   }
   bool Apply(const BranchChannel& object) const;
-  bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-  bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
+  bool Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const;
+  [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
+  [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Print() const;
 

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -90,6 +90,7 @@ class SimpleCut {
   }
   bool Apply(const BranchChannel& object) const;
   bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
+  bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   void Print() const;
 

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -89,7 +89,7 @@ class SimpleCut {
     return lambda_(variables);
   }
   bool Apply(const BranchChannel& object) const;
-  bool Apply(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const;
+  bool Apply(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
   [[deprecated]] bool Apply(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -71,14 +71,14 @@ double Variable::GetValue(const BranchChannel& object) const {
   return lambda_(vars_);
 }
 
-double Variable::GetValue(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const {
+double Variable::GetValue(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const {
   assert(is_init_);
   vars_.clear();
   for (const auto& field : fields_) {
     bool success{false};
     for(auto& bi : bch_id) {
       if(field.GetBranchId() == bi.second) {
-        vars_.emplace_back(bi.first[field]);
+        vars_.emplace_back(bi.first->Value(field));
         success = true;
         break;
       }
@@ -91,12 +91,12 @@ double Variable::GetValue(std::vector<std::pair<const BranchChannel&, size_t>>& 
 }
 
 double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
-  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}};
+  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}};
   return GetValue(vec);
 }
 
 double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}, {c, c_id}};
+  std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
   return GetValue(vec);
 }
 

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -71,36 +71,29 @@ double Variable::GetValue(const BranchChannel& object) const {
   return lambda_(vars_);
 }
 
-double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
+double Variable::GetValue(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const {
   assert(is_init_);
   vars_.clear();
   for (const auto& field : fields_) {
-    if (field.GetBranchId() == a_id)
-      vars_.emplace_back(a[field]);
-    else if (field.GetBranchId() == b_id)
-      vars_.emplace_back(b[field]);
-    else {
-      throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
+    for(auto& bi : bch_id) {
+      if(field.GetBranchId() == bi.second) {
+        vars_.emplace_back(bi.first[field]);
+        break;
+      }
     }
+    throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
   }
   return lambda_(vars_);
 }
 
+double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const {
+  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}};
+  return GetValue(vec);
+}
+
 double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-  assert(is_init_);
-  vars_.clear();
-  for (const auto& field : fields_) {
-    if (field.GetBranchId() == a_id)
-      vars_.emplace_back(a[field]);
-    else if (field.GetBranchId() == b_id)
-      vars_.emplace_back(b[field]);
-    else if (field.GetBranchId() == c_id)
-      vars_.emplace_back(c[field]);
-    else {
-      throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
-    }
-  }
-  return lambda_(vars_);
+  std::vector<std::pair<const BranchChannel&, size_t>> vec = {{a, a_id}, {b, b_id}, {c, c_id}};
+  return GetValue(vec);
 }
 
 std::string Variable::GetBranchName() const {

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -87,6 +87,9 @@ double Variable::GetValue(std::vector<std::pair<const BranchChannel*, size_t>>& 
       throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
     }
   }
+  for(auto& bi : bch_id) {
+    delete bi.first;
+  }
   return lambda_(vars_);
 }
 

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -104,11 +104,6 @@ double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChann
   return result;
 }
 
-// double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
-//   std::vector<std::pair<const BranchChannel*, size_t>> vec = {{&a, a_id}, {&b, b_id}, {&c, c_id}};
-//   return GetValue(vec);
-// }
-
 std::string Variable::GetBranchName() const {
   if (n_branches_ != 1) {
     throw std::runtime_error("Number of branches is not 1!");

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -75,13 +75,17 @@ double Variable::GetValue(std::vector<std::pair<const BranchChannel&, size_t>>& 
   assert(is_init_);
   vars_.clear();
   for (const auto& field : fields_) {
+    bool success{false};
     for(auto& bi : bch_id) {
       if(field.GetBranchId() == bi.second) {
         vars_.emplace_back(bi.first[field]);
+        success = true;
         break;
       }
     }
-    throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
+    if(!success) {
+      throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
+    }
   }
   return lambda_(vars_);
 }

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -90,9 +90,6 @@ double Variable::GetValue(std::vector<const BranchChannel*>& bch, std::vector<si
       throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
     }
   }
-  for(auto& b : bch) {
-    delete b;
-  }
   return lambda_(vars_);
 }
 
@@ -101,7 +98,10 @@ double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChann
   BranchChannel* b_ptr = new BranchChannel(std::move(b));
   std::vector<const BranchChannel*> brch_vec{a_ptr, b_ptr};
   std::vector<size_t> id_vec{a_id, b_id};
-  return GetValue(brch_vec, id_vec);
+  double result = GetValue(brch_vec, id_vec);
+  delete a_ptr;
+  delete b_ptr;
+  return result;
 }
 
 // double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -85,6 +85,24 @@ double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChann
   }
   return lambda_(vars_);
 }
+
+double Variable::GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const {
+  assert(is_init_);
+  vars_.clear();
+  for (const auto& field : fields_) {
+    if (field.GetBranchId() == a_id)
+      vars_.emplace_back(a[field]);
+    else if (field.GetBranchId() == b_id)
+      vars_.emplace_back(b[field]);
+    else if (field.GetBranchId() == c_id)
+      vars_.emplace_back(c[field]);
+    else {
+      throw std::runtime_error("Variable::Fill - Cannot fill value from branch " + field.GetBranchName());
+    }
+  }
+  return lambda_(vars_);
+}
+
 std::string Variable::GetBranchName() const {
   if (n_branches_ != 1) {
     throw std::runtime_error("Number of branches is not 1!");

--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -63,7 +63,7 @@ class Variable {
   ANALYSISTREE_ATTR_NODISCARD std::set<std::string> GetBranches() const;
   ANALYSISTREE_ATTR_NODISCARD std::string GetBranchName() const;
 
-  double GetValue(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const;
+  double GetValue(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const;
   [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
   [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 

--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -63,8 +63,9 @@ class Variable {
   ANALYSISTREE_ATTR_NODISCARD std::set<std::string> GetBranches() const;
   ANALYSISTREE_ATTR_NODISCARD std::string GetBranchName() const;
 
-  double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-  double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
+  double GetValue(std::vector<std::pair<const BranchChannel&, size_t>>& bch_id) const;
+  [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
+  [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   template<class T>
   double GetValue(const T& object) const {

--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -63,9 +63,9 @@ class Variable {
   ANALYSISTREE_ATTR_NODISCARD std::set<std::string> GetBranches() const;
   ANALYSISTREE_ATTR_NODISCARD std::string GetBranchName() const;
 
-  double GetValue(std::vector<std::pair<const BranchChannel*, size_t>>& bch_id) const;
+  double GetValue(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const;
   [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-  [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
+//   [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   template<class T>
   double GetValue(const T& object) const {

--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -64,6 +64,7 @@ class Variable {
   ANALYSISTREE_ATTR_NODISCARD std::string GetBranchName() const;
 
   double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
+  double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   template<class T>
   double GetValue(const T& object) const {

--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -65,7 +65,6 @@ class Variable {
 
   double GetValue(std::vector<const BranchChannel*>& bch, std::vector<size_t>& id) const;
   [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id) const;
-//   [[deprecated]] double GetValue(const BranchChannel& a, size_t a_id, const BranchChannel& b, size_t b_id, const BranchChannel& c, size_t c_id) const;
 
   template<class T>
   double GetValue(const T& object) const {


### PR DESCRIPTION
Enabled operating AT::Variable (e.g. AtQA task or Cuts etc.) consisting from any number of EventHeader branches and up to 2 channelized (Track, Particle, Hit) branches.