### PR TITLE
Friend Chain

### DIFF
--- a/infra/Chain.hpp
+++ b/infra/Chain.hpp
@@ -93,6 +93,16 @@ class Chain : public TChain {
     return match->second;
   }
 
+  /**
+ * @brief Clones tree without friends
+ */
+  TTree* CloneChain(int nentries=0);
+
+  /**
+ * @brief Clones Configuration of input Chain without friends
+ */
+  Configuration* CloneConfiguration() const;
+
  protected:
   void InitChain();
   void InitConfiguration();
@@ -109,6 +119,12 @@ class Chain : public TChain {
  */
   template<class T>
   static T* GetObjectFromFileList(const std::string& filelist, const std::string& name);
+
+  /**
+ * @return Vector of pointers on all TChains in AT::Chain - main one and
+ * friended ones
+ */
+  std::vector<TChain*> GetTChains();
 
   std::string LookupAlias(const std::vector<std::string>& names, const std::string& name, size_t copy = 0);
 

--- a/infra/TaskManager.cpp
+++ b/infra/TaskManager.cpp
@@ -122,9 +122,10 @@ void TaskManager::Finish() {
     std::cout << "Output file is " << out_file_name_ << std::endl;
     std::cout << "Output tree is " << out_tree_name_ << std::endl;
     out_file_->cd();
-    if(out_tree_->GetListOfFriends()->GetEntries() != 0) {
-      std::cout << "Warining: TaskManager::Finish() - out_tree_ has friends\
-      which can be wrongly read from the output file\n";
+    if(out_tree_->GetListOfFriends() != nullptr) {
+      if(out_tree_->GetListOfFriends()->GetEntries() != 0) {
+        std::cout << "Warining: TaskManager::Finish() - out_tree_ has friends which can be wrongly read from the output file\n";
+      }
     }
     out_tree_->Write();
     configuration_->Write("Configuration");

--- a/infra/TaskManager.cpp
+++ b/infra/TaskManager.cpp
@@ -68,7 +68,7 @@ void TaskManager::InitOutChain() {
     out_tree_ = new TTree(out_tree_name_.c_str(), "AnalysisTree");
   } else if (write_mode_ == eBranchWriteMode::kCopyTree) {
     assert(configuration_ && data_header_ && chain_);// input should exist
-    *configuration_ = *(chain_->GetConfiguration());
+    configuration_ = chain_->CloneConfiguration();
     *(data_header_) = *(chain_->GetDataHeader());
     for (auto& brex : branches_exclude_) {
       if (chain_->CheckBranchExistence(brex) == 1) {
@@ -80,7 +80,7 @@ void TaskManager::InitOutChain() {
       }
       configuration_->RemoveBranchConfig(brex);
     }
-    out_tree_ = chain_->CloneTree(0);
+    out_tree_ = chain_->CloneChain(0);
     out_tree_->SetName(out_tree_name_.c_str());
     data_header_ = chain_->GetDataHeader();
     chain_->SetBranchStatus("*", true);
@@ -122,6 +122,10 @@ void TaskManager::Finish() {
     std::cout << "Output file is " << out_file_name_ << std::endl;
     std::cout << "Output tree is " << out_tree_name_ << std::endl;
     out_file_->cd();
+    if(out_tree_->GetListOfFriends()->GetEntries() != 0) {
+      std::cout << "Warining: TaskManager::Finish() - out_tree_ has friends\
+      which can be wrongly read from the output file\n";
+    }
     out_tree_->Write();
     configuration_->Write("Configuration");
     data_header_->Write("DataHeader");


### PR DESCRIPTION
When AT::Infra::TaskManager was initialized with vector of filelists (via friending), and the output chain was created in Copy mode, then friended tree caused errors (non-fatal, but anyway) when opening the output root-file.
Now this problem is fixed by explicit removal of friended trees from the output chain and friended tree branches from the output configuration.