### PR TITLE
fix bug when 'ones' field used in Variable

### DIFF
--- a/infra/BranchChannel.cpp
+++ b/infra/BranchChannel.cpp
@@ -57,13 +57,14 @@ double BranchChannel::Value(const Field& v) const {
   //  assert(v.GetBranchId() == branch_->GetId()); // TODO
   assert(v.IsInitialized());
 
+  if(v.GetName() == "ones") return 1;
+
   using AnalysisTree::Types;
   switch (v.GetFieldType()) {
     case Types::kFloat: return ANALYSISTREE_UTILS_VISIT(get_field_struct<float>(v.GetFieldId()), data_ptr_);
     case Types::kInteger: return ANALYSISTREE_UTILS_VISIT(get_field_struct<int>(v.GetFieldId()), data_ptr_);
-    case Types::kBool:
-      return ANALYSISTREE_UTILS_VISIT(get_field_struct<bool>(v.GetFieldId()), data_ptr_);
-      //    default: throw std::runtime_error("Field type is not correct!"); //NOTE commented because of Ones field
+    case Types::kBool: return ANALYSISTREE_UTILS_VISIT(get_field_struct<bool>(v.GetFieldId()), data_ptr_);
+    default: throw std::runtime_error("Field type is not correct!"); //NOTE commented because of Ones field NOTE now commented again
   }
 }
 

--- a/infra/Field.cpp
+++ b/infra/Field.cpp
@@ -46,7 +46,7 @@ void Field::Init(const BranchConfig& branch_conf) {
   branch_type_ = branch_conf.GetType();
   field_id_ = branch_conf.GetFieldId(field_);
   field_type_ = branch_conf.GetFieldType(field_);
-  if (field_id_ == UndefValueInt) {
+  if (field_id_ == UndefValueInt && field_!="ones") {
     std::cout << "WARNING!! Field::Init - " << field_ << " is not found in branch " << branch_ << std::endl;
   }
   is_init_ = true;


### PR DESCRIPTION
There is a possibility to create a Variable "Ones" (e.g. when filling the multiplicity of tracks etc). The field corresponding to it does not exist and thus does not belong to any type (float, int, bool). In the current implementation it was implicitly realized in **switch** operator, however in different optimization modes (Debug vs Release) the behavior was different, and maybe undefined.
This PR fixes this bug, explicitly operating the case of quasi-field "Ones".