### PR TITLE
provide a function for IfEmptyVariableConvertToOnes

### DIFF
--- a/infra/AnalysisEntry.hpp
+++ b/infra/AnalysisEntry.hpp
@@ -29,9 +29,7 @@ class AnalysisEntry {
   explicit AnalysisEntry(std::vector<Variable> vars, Cuts* cuts = nullptr, Variable vars4weight={}) : vars_(std::move(vars)),
                                                                                                       var4weight_(std::move(vars4weight)),
                                                                                                       cuts_(cuts) {
-    if(var4weight_.GetNumberOfBranches() == 0) {
-      var4weight_ = Variable::FromString(vars_.at(0).GetBranchName() + ".ones");
-    }
+    var4weight_.IfEmptyVariableConvertToOnes(vars_.at(0));
     FillBranchNames();
   };
 

--- a/infra/Variable.cpp
+++ b/infra/Variable.cpp
@@ -118,5 +118,11 @@ std::set<std::string> Variable::GetBranches() const {
   }
   return branches;
 }
+void Variable::IfEmptyVariableConvertToOnes(const Variable& var) {
+  if (GetNumberOfBranches() == 0) {
+    const std::string name = *var.GetBranches().begin();
+    *this = Variable::FromString(name + ".ones");
+  }
+}
 
 }// namespace AnalysisTree

--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -82,6 +82,8 @@ class Variable {
 
   void Print() const;
 
+  void IfEmptyVariableConvertToOnes(const Variable& var);
+
  protected:
   std::string name_;
   std::vector<Field> fields_{};


### PR DESCRIPTION
1. Provide a function for IfEmptyVariableConvertToOnes.
2. Additionally fix bug when a reference (argument) variable is constructed from several branches, and GetBranchName() is not allowed.