### PR TITLE
Entries weights

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(AnalysisTree
         LANGUAGES CXX)
 
 # by default build optimized code
-if(NOT DEFINED CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RELEASE)
 endif()
 
@@ -50,6 +50,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb -g -DDEBUG -D__DEBUG -Wall -Wextra")
 #set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb -g -DDEBUG -D__DEBUG -Wall -Wextra --coverage")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ftree-vectorize -ffast-math -DNODEBUG")
 message(STATUS "Using CXX flags for ${CMAKE_BUILD_TYPE}: ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
+message(STATUS "Using CXX standard " ${CMAKE_CXX_STANDARD})
 
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 list(APPEND CMAKE_PREFIX_PATH ${ROOTSYS})

--- a/infra/AnalysisTask.cpp
+++ b/infra/AnalysisTask.cpp
@@ -33,7 +33,7 @@ std::pair<int, std::vector<int>> AnalysisTask::AddEntry(const AnalysisEntry& var
   std::vector<int> var_ids(vars.GetVariables().size());
 
   for (size_t ivar = 0; ivar < entries_.size(); ++ivar) {
-    if (vars.GetBranchNames() == entries_[ivar].GetBranchNames() && Cuts::Equal(vars.GetCuts(), entries_[ivar].GetCuts())) {//branch exists
+    if (vars.GetBranchNames() == entries_[ivar].GetBranchNames() && Cuts::Equal(vars.GetCuts(), entries_[ivar].GetCuts()) && vars.GetVariableForWeight() == entries_[ivar].GetVariableForWeight()) {//branch exists
       for (size_t i = 0; i < vars.GetVariables().size(); ++i) {
         var_ids[i] = entries_[ivar].AddVariable(vars.GetVariables()[i]);
       }


### PR DESCRIPTION
For ATQA: split entries if they differ with weights (otherwise if there are two similar entries which differ in weights only, they are overwritten).