### PR TITLE
Diff Patch into install/bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,3 +140,12 @@ install(FILES
         COMPONENT
         Devel
         )
+
+install(FILES
+        ${CMAKE_BINARY_DIR}/AnalysisTreeDiff.patch
+        DESTINATION
+        bin
+        COMPONENT
+        Devel
+        OPTIONAL
+        )

--- a/cmake/AnalysisTreeHashWriter.sh
+++ b/cmake/AnalysisTreeHashWriter.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-FILE=AnalysisTreeHash.sh
-if [ -f $FILE ]; then
-rm $FILE
+FILE_HASH=AnalysisTreeHash.sh
+FILE_DIFF=AnalysisTreeDiff.patch
+if [ -f $FILE_HASH ]; then
+rm $FILE_HASH
 fi
 
 SRC_DIR=${1}
@@ -12,14 +13,15 @@ if [ -d ".git" ]; then
 GITCOMMIT=$(git rev-parse HEAD)
 GITSTATUS=$(git status --porcelain)
 cd -
-echo "export ANALYSIS_TREE_COMMIT_HASH=${GITCOMMIT}" >> $FILE
+echo "export ANALYSIS_TREE_COMMIT_HASH=${GITCOMMIT}" >> $FILE_HASH
 if [ -z "${GITSTATUS}" ]; then
-echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=TRUE" >> $FILE
+echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=TRUE" >> $FILE_HASH
 else
-echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=FALSE" >> $FILE
+echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=FALSE" >> $FILE_HASH
+git diff >> $FILE_DIFF
 fi
 else
 cd -
-echo "export ANALYSIS_TREE_COMMIT_HASH=NOT_A_GIT_REPO" >> $FILE
-echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=NOT_A_GIT_REPO" >> $FILE
+echo "export ANALYSIS_TREE_COMMIT_HASH=NOT_A_GIT_REPO" >> $FILE_HASH
+echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=NOT_A_GIT_REPO" >> $FILE_HASH
 fi


### PR DESCRIPTION
Following PR [#126](https://github.com/HeavyIonAnalysis/AnalysisTree/pull/126) 
If ANALYSIS_TREE_COMMIT_ORIGINAL variable is FALSE (i.e. there were changes since last commit and git status returns non-empty output), the git diff output is saved in .patch format and propagated into the install/bin directory.