### PR TITLE
Channel -> entry plaining

### DIFF
--- a/cmake/AnalysisTreeConfig.sh.in
+++ b/cmake/AnalysisTreeConfig.sh.in
@@ -2,6 +2,7 @@ source ${ROOT_BINDIR}/thisroot.sh
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${CMAKE_INSTALL_PREFIX}/lib
 export ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:${CMAKE_INSTALL_PREFIX}/include/AnalysisTree
 export PATH=$PATH:${CMAKE_INSTALL_PREFIX}/bin
+export AnalysisTree_DIR=${CMAKE_INSTALL_PREFIX}/lib/cmake/AnalysisTree
 if [ -f "${CMAKE_INSTALL_PREFIX}/bin/AnalysisTreeHash.sh" ]; then
 source ${CMAKE_INSTALL_PREFIX}/bin/AnalysisTreeHash.sh
 fi

--- a/cmake/AnalysisTreeHashWriter.sh
+++ b/cmake/AnalysisTreeHashWriter.sh
@@ -10,9 +10,11 @@ SRC_DIR=${1}
 
 cd $SRC_DIR
 if [ -d ".git" ]; then
+GITTAG=$(git describe --tags)
 GITCOMMIT=$(git rev-parse HEAD)
 GITSTATUS=$(git status --porcelain)
 cd -
+echo "export ANALYSIS_TREE_TAG=\"${GITTAG}\"" >> $FILE_HASH
 echo "export ANALYSIS_TREE_COMMIT_HASH=${GITCOMMIT}" >> $FILE_HASH
 if [ -z "${GITSTATUS}" ]; then
 echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=TRUE" >> $FILE_HASH
@@ -22,6 +24,7 @@ git diff >> $FILE_DIFF
 fi
 else
 cd -
+echo "export ANALYSIS_TREE_TAG=NOT_A_GIT_REPO" >> $FILE_HASH
 echo "export ANALYSIS_TREE_COMMIT_HASH=NOT_A_GIT_REPO" >> $FILE_HASH
 echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=NOT_A_GIT_REPO" >> $FILE_HASH
 fi

--- a/infra/TaskManager.cpp
+++ b/infra/TaskManager.cpp
@@ -169,4 +169,13 @@ TaskManager::~TaskManager() {
   }
   ClearTasks();
 }
+void TaskManager::Exec() {
+  for (auto* task : tasks_) {
+    if (!task->IsGoodEvent(*chain_)) continue;
+    task->Exec();
+  }
+  if (fill_out_tree_ && is_update_entry_in_exec_) {
+    FillOutput();
+  }
+}
 }// namespace AnalysisTree

--- a/infra/TaskManager.cpp
+++ b/infra/TaskManager.cpp
@@ -115,16 +115,21 @@ void TaskManager::Run(long long nEvents) {
 }
 
 void TaskManager::WriteCommitInfo() {
+  std::string tag = std::getenv("ANALYSIS_TREE_TAG") ? std::getenv("ANALYSIS_TREE_TAG") : "unknown";
   std::string commit = std::getenv("ANALYSIS_TREE_COMMIT_HASH") ? std::getenv("ANALYSIS_TREE_COMMIT_HASH") : "unknown";
   std::string is_original = std::getenv("ANALYSIS_TREE_COMMIT_ORIGINAL") ? std::getenv("ANALYSIS_TREE_COMMIT_ORIGINAL") : "unknown";
+  TNamed("AnalysisTree_tag", tag).Write();
   TNamed("AnalysisTree_commit_hash", commit).Write();
   TNamed("AnalysisTree_commit_is_original", is_original).Write();
 }
 
 void TaskManager::PrintCommitInfo() {
+  std::string tag = std::getenv("ANALYSIS_TREE_TAG") ? std::getenv("ANALYSIS_TREE_TAG") : "unknown";
   std::string commit = std::getenv("ANALYSIS_TREE_COMMIT_HASH") ? std::getenv("ANALYSIS_TREE_COMMIT_HASH") : "unknown";
   std::string is_original = std::getenv("ANALYSIS_TREE_COMMIT_ORIGINAL") ? std::getenv("ANALYSIS_TREE_COMMIT_ORIGINAL") : "unknown";
-  std::cout << "ANALYSIS_TREE_COMMIT_HASH = " << commit << "\n" << "ANALYSIS_TREE_COMMIT_ORIGINAL = " << is_original << "\n";
+  std::cout << "ANALYSIS_TREE_TAG = " << tag << "\n"
+            << "ANALYSIS_TREE_COMMIT_HASH = " << commit << "\n"
+            << "ANALYSIS_TREE_COMMIT_ORIGINAL = " << is_original << "\n";
 }
 
 void TaskManager::Finish() {

--- a/infra/TaskManager.hpp
+++ b/infra/TaskManager.hpp
@@ -145,15 +145,7 @@ class TaskManager {
   }
   void FillOutput() { out_tree_->Fill(); }
 
-  void Exec() {
-    for (auto* task : tasks_) {
-      if (!task->IsGoodEvent(*chain_)) continue;
-      task->Exec();
-    }
-    if (fill_out_tree_) {
-      FillOutput();
-    }
-  }
+  void Exec();
 
   std::vector<Task*>& Tasks() { return tasks_; }
 
@@ -167,6 +159,7 @@ class TaskManager {
   void SetBranchesExclude(std::vector<std::string> brex) { branches_exclude_ = std::move(brex); }
   void SetVerbosityPeriod(int value) { verbosity_period_ = value; }
   void SetIsWriteHashInfo(bool is=true) { is_write_hash_info_ = is; }
+  void SetIsUpdateEntryInExec(bool is = true) { is_update_entry_in_exec_ = is; }
 
   void ClearTasks() { tasks_.clear(); }
 
@@ -176,8 +169,8 @@ class TaskManager {
 
   void InitOutChain();
   void InitTasks();
-  void WriteCommitInfo();
-  void PrintCommitInfo();
+  static void WriteCommitInfo();
+  static void PrintCommitInfo();
 
   // input data members
   Chain* chain_{nullptr};
@@ -198,6 +191,7 @@ class TaskManager {
   eBranchWriteMode write_mode_{eBranchWriteMode::kCreateNewTree};
   bool is_init_{false};
   bool fill_out_tree_{false};
+  bool is_update_entry_in_exec_{true};
   bool read_in_tree_{false};
   bool is_owns_tasks_{true};
   bool is_write_hash_info_{true};


### PR DESCRIPTION
Make optional creating a new event in each call TaskManager::Exec() that will allow to create a new entry for each channel (usually in AnalysisTree entry <-> event).