### PR TITLE
ATHashWriter bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ configure_package_config_file(
 add_custom_target(HashWriteTarget ALL) # Silent call of target. I don't know how to avoid it, sorry :)
 add_custom_command(TARGET HashWriteTarget
                    POST_BUILD
-                   COMMAND /bin/sh ${CMAKE_SOURCE_DIR}/cmake/AnalysisTreeHashWriter.sh ${CMAKE_SOURCE_DIR}
+                   COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/cmake/AnalysisTreeHashWriter.sh ${CMAKE_CURRENT_SOURCE_DIR}
                    )
 
 install(EXPORT ${PROJECT_NAME}Targets


### PR DESCRIPTION
bugfix of ATHash generating in case when AT is an external package:
CMAKE_SOURCE_DIR which is location of CMakeLists.txt of the global package is replaced with CMAKE_CURRENT_SOURCE_DIR which is location of CMakeLists.txt of AnalysisTree when it is external