### PR TITLE
Fields removal

### DIFF
--- a/core/BranchConfig.cpp
+++ b/core/BranchConfig.cpp
@@ -128,7 +128,7 @@ BranchConfig BranchConfig::CloneAndMerge(const BranchConfig& attached) const {
     result.AddField<bool>(name2 + "_" + field.first, name2 + ": " + field.second.title_);
   }
 
-  if(type1!=DetType::kEventHeader && attached.GetType()!=DetType::kEventHeader) {
+  if (type1 != DetType::kEventHeader && attached.GetType() != DetType::kEventHeader) {
     result.AddField<int>("matching_case", "0 - both present, 1 - only first present, 2 - only second present");
   }
 
@@ -156,25 +156,25 @@ template<typename T>
 void VectorConfig<T>::RemoveField(const std::string& name, int id) {
   auto iter = map_.find(name);
   map_.erase(iter);
-  for(auto& m : map_) {
-    if(m.second.id_>id) {
-      m.second.id_ --;
+  for (auto& m : map_) {
+    if (m.second.id_ > id) {
+      m.second.id_--;
     }
   }
 }
 
 void BranchConfig::RemoveField(const std::string& name) {
-  if(!HasField(name)) {
+  if (!HasField(name)) {
     throw std::runtime_error("BranchConfig::RemoveField(): no field " + name + " to be removed");
   }
   auto field_type = GetFieldType(name);
   auto field_id = GetFieldId(name);
-  if(field_id<0) {
+  if (field_id < 0) {
     throw std::runtime_error("BranchConfig::RemoveField(): default field " + name + " cannot be removed");
   }
-  if(field_type == Types::kInteger) VectorConfig<int>::RemoveField(name, field_id);
-  if(field_type == Types::kFloat) VectorConfig<float>::RemoveField(name, field_id);
-  if(field_type == Types::kBool) VectorConfig<bool>::RemoveField(name, field_id);
+  if (field_type == Types::kInteger) VectorConfig<int>::RemoveField(name, field_id);
+  if (field_type == Types::kFloat) VectorConfig<float>::RemoveField(name, field_id);
+  if (field_type == Types::kBool) VectorConfig<bool>::RemoveField(name, field_id);
 }
 
 void BranchConfig::GuaranteeFieldNameVacancy(const std::string& name) const {

--- a/core/BranchConfig.hpp
+++ b/core/BranchConfig.hpp
@@ -105,6 +105,7 @@ class VectorConfig {
 
  protected:
   static std::vector<std::string> SplitString(const std::string& input);
+  void RemoveField(const std::string& name, int id);
   MapType map_{};
   ShortInt_t size_{0};
   ClassDef(VectorConfig, 2)
@@ -148,6 +149,14 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
   void AddField(const std::string& name, ShortInt_t id, const std::string& title = "") {
     GuaranteeFieldNameVacancy(name);
     VectorConfig<T>::AddField(name, id, title);
+  }
+
+  void RemoveField(const std::string& name);
+
+  void RemoveFields(const std::vector<std::string>& names) {
+    for(auto& n : names) {
+      RemoveField(n);
+    }
   }
 
   // Getters

--- a/core/BranchConfig.hpp
+++ b/core/BranchConfig.hpp
@@ -154,7 +154,7 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
   void RemoveField(const std::string& name);
 
   void RemoveFields(const std::vector<std::string>& names) {
-    for(auto& n : names) {
+    for (auto& n : names) {
       RemoveField(n);
     }
   }


### PR DESCRIPTION
1. Enabled removing of user-defined fields from the config of the output branch (can be useful in AnalysisTree post-processing tasks such as Pid, Centrality, BranchWizard etc.).
_Note: this feature was not tested extensively, only basic checks were done. So you are welcome to test it, and before that use feature carefully :)_
2. Fixed bug introduced in PR [#125 ](https://github.com/HeavyIonAnalysis/AnalysisTree/pull/125): variable 'matching_case' was added each time when EventHeader branch was attached to the output BranchConfig, that was not OK. Now it is fixed.