### PR TITLE
Dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,5 +147,4 @@ install(FILES
         bin
         COMPONENT
         Devel
-        OPTIONAL
         )

--- a/cmake/AnalysisTreeHashWriter.sh
+++ b/cmake/AnalysisTreeHashWriter.sh
@@ -3,7 +3,7 @@
 FILE_HASH=AnalysisTreeHash.sh
 FILE_DIFF=AnalysisTreeDiff.patch
 if [ -f $FILE_HASH ]; then
-rm $FILE_HASH
+rm $FILE_HASH $FILE_DIFF
 fi
 
 SRC_DIR=${1}
@@ -20,8 +20,8 @@ if [ -z "${GITSTATUS}" ]; then
 echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=TRUE" >> $FILE_HASH
 else
 echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=FALSE" >> $FILE_HASH
-git diff >> $FILE_DIFF
 fi
+git diff >> $FILE_DIFF
 else
 cd -
 echo "export ANALYSIS_TREE_TAG=NOT_A_GIT_REPO" >> $FILE_HASH

--- a/cmake/AnalysisTreeHashWriter.sh
+++ b/cmake/AnalysisTreeHashWriter.sh
@@ -2,29 +2,31 @@
 
 FILE_HASH=AnalysisTreeHash.sh
 FILE_DIFF=AnalysisTreeDiff.patch
-if [ -f $FILE_HASH ]; then
-rm $FILE_HASH $FILE_DIFF
-fi
+for F in $FILE_HASH $FILE_DIFF; do
+  if [ -f $F ]; then
+    rm $F
+  fi
+done
 
 SRC_DIR=${1}
 
 cd $SRC_DIR
 if [ -d ".git" ]; then
-GITTAG=$(git describe --tags)
-GITCOMMIT=$(git rev-parse HEAD)
-GITSTATUS=$(git status --porcelain)
-cd -
-echo "export ANALYSIS_TREE_TAG=\"${GITTAG}\"" >> $FILE_HASH
-echo "export ANALYSIS_TREE_COMMIT_HASH=${GITCOMMIT}" >> $FILE_HASH
-if [ -z "${GITSTATUS}" ]; then
-echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=TRUE" >> $FILE_HASH
+  GITTAG=$(git describe --tags)
+  GITCOMMIT=$(git rev-parse HEAD)
+  GITSTATUS=$(git status --porcelain)
+  cd -
+  echo "export ANALYSIS_TREE_TAG=\"${GITTAG}\"" >> $FILE_HASH
+  echo "export ANALYSIS_TREE_COMMIT_HASH=${GITCOMMIT}" >> $FILE_HASH
+  if [ -z "${GITSTATUS}" ]; then
+    echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=TRUE" >> $FILE_HASH
+  else
+    echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=FALSE" >> $FILE_HASH
+    git diff >> $FILE_DIFF
+  fi
 else
-echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=FALSE" >> $FILE_HASH
-fi
-git diff >> $FILE_DIFF
-else
-cd -
-echo "export ANALYSIS_TREE_TAG=NOT_A_GIT_REPO" >> $FILE_HASH
-echo "export ANALYSIS_TREE_COMMIT_HASH=NOT_A_GIT_REPO" >> $FILE_HASH
-echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=NOT_A_GIT_REPO" >> $FILE_HASH
+  cd -
+  echo "export ANALYSIS_TREE_TAG=NOT_A_GIT_REPO" >> $FILE_HASH
+  echo "export ANALYSIS_TREE_COMMIT_HASH=NOT_A_GIT_REPO" >> $FILE_HASH
+  echo "export ANALYSIS_TREE_COMMIT_ORIGINAL=NOT_A_GIT_REPO" >> $FILE_HASH
 fi

--- a/core/BranchConfig.cpp
+++ b/core/BranchConfig.cpp
@@ -14,7 +14,7 @@ void BranchConfig::GenerateId() {
   id_ = id_hasher(name_);
 }
 
-BranchConfig::BranchConfig(std::string name, DetType type) : name_(std::move(name)), type_(type) {
+BranchConfig::BranchConfig(std::string name, DetType type, std::string title) : name_(std::move(name)), type_(type), title_(std::move(title)) {
   GenerateId();
 
   if (type_ == DetType::kTrack) {
@@ -184,13 +184,18 @@ void BranchConfig::GuaranteeFieldNameVacancy(const std::string& name) const {
 }
 
 void BranchConfig::Print() const {
-  std::cout << "Branch " << name_ << " (id=" << id_ << ") consists of:" << std::endl;
-  std::cout << "Floating fields:" << std::endl;
+  std::cout << "Branch " << name_ << " (" << title_ << ") consists of:" << std::endl;
+  std::cout << "\nFloating fields:" << std::endl;
   VectorConfig<float>::Print();
-  std::cout << "Integer fields:" << std::endl;
+  std::cout << "\nInteger fields:" << std::endl;
   VectorConfig<int>::Print();
-  std::cout << "Boolean fields:" << std::endl;
+  std::cout << "\nBoolean fields:" << std::endl;
   VectorConfig<bool>::Print();
   //  std::cout << std::endl;
 }
+
+void BranchConfig::PrintBranchId() const {
+  std::cout << "Branch " << name_ << " (id=" << id_ << ")" << std::endl;
+}
+
 }// namespace AnalysisTree

--- a/core/BranchConfig.cpp
+++ b/core/BranchConfig.cpp
@@ -18,46 +18,46 @@ BranchConfig::BranchConfig(std::string name, DetType type, std::string title) : 
   GenerateId();
 
   if (type_ == DetType::kTrack) {
-    VectorConfig<float>::AddField("px", TrackFields::kPx, "GeV/c");
-    VectorConfig<float>::AddField("py", TrackFields::kPy, "GeV/c");
-    VectorConfig<float>::AddField("pz", TrackFields::kPz, "GeV/c");
-    VectorConfig<float>::AddField("pT", TrackFields::kPt, "GeV/c");
-    VectorConfig<float>::AddField("phi", TrackFields::kPhi, "azimuthal angle");
-    VectorConfig<float>::AddField("eta", TrackFields::kEta, "pseudorapidity");
-    VectorConfig<float>::AddField("p", TrackFields::kP, "GeV/c");
+    VectorConfig<float>::AddField("px", TrackFields::kPx, "X-projection of the momentum of the track, GeV/c");
+    VectorConfig<float>::AddField("py", TrackFields::kPy, "Y-projection of the momentum of the track, GeV/c");
+    VectorConfig<float>::AddField("pz", TrackFields::kPz, "Z-projection of the momentum of the track, GeV/c");
+    VectorConfig<float>::AddField("pT", TrackFields::kPt, "Transverse momentum of the track, GeV/c");
+    VectorConfig<float>::AddField("phi", TrackFields::kPhi, "Azimuthal angle of the track, rad");
+    VectorConfig<float>::AddField("eta", TrackFields::kEta, "Pseudorapidity of the track");
+    VectorConfig<float>::AddField("p", TrackFields::kP, "Full momentum of the track, GeV/c");
     VectorConfig<int>::AddField("q", TrackFields::kQ, "Charge of the track (or its sign when absolute value unknown)");
-    VectorConfig<int>::AddField("id", TrackFields::kId, "unique id");
+    VectorConfig<int>::AddField("id", TrackFields::kId, "Unique id of the track within current event; assigned automatically (not by user)");
   } else if (type_ == DetType::kParticle) {
-    VectorConfig<float>::AddField("px", ParticleFields::kPx, "GeV/c");
-    VectorConfig<float>::AddField("py", ParticleFields::kPy, "GeV/c");
-    VectorConfig<float>::AddField("pz", ParticleFields::kPz, "GeV/c");
-    VectorConfig<float>::AddField("pT", ParticleFields::kPt, "GeV/c");
-    VectorConfig<float>::AddField("phi", ParticleFields::kPhi, "azimuthal angle");
-    VectorConfig<float>::AddField("eta", ParticleFields::kEta, "pseudorapidity");
-    VectorConfig<float>::AddField("mass", ParticleFields::kMass, "GeV/c^2");
-    VectorConfig<float>::AddField("p", ParticleFields::kP, "GeV/c");
-    VectorConfig<float>::AddField("E", ParticleFields::kEnergy, "full energy, GeV");
-    VectorConfig<float>::AddField("T", ParticleFields::kKineticEnergy, "kinetic energy, GeV");
-    VectorConfig<float>::AddField("rapidity", ParticleFields::kRapidity, "in Lab. frame");
-    VectorConfig<int>::AddField("q", ParticleFields::kQ, "Charge of the particle");
-    VectorConfig<int>::AddField("pid", ParticleFields::kPid, "PDG code");
-    VectorConfig<int>::AddField("id", ParticleFields::kId, "unique id");
+    VectorConfig<float>::AddField("px", ParticleFields::kPx, "X-projection of the momentum of the particle, GeV/c");
+    VectorConfig<float>::AddField("py", ParticleFields::kPy, "Y-projection of the momentum of the particle, GeV/c");
+    VectorConfig<float>::AddField("pz", ParticleFields::kPz, "Z-projection of the momentum of the particle, GeV/c");
+    VectorConfig<float>::AddField("pT", ParticleFields::kPt, "Transverse momentum of the particle, GeV/c");
+    VectorConfig<float>::AddField("phi", ParticleFields::kPhi, "Azimuthal angle of the particle, rad");
+    VectorConfig<float>::AddField("eta", ParticleFields::kEta, "Pseudorapidity of the particle");
+    VectorConfig<float>::AddField("mass", ParticleFields::kMass, "Mass of the particle, GeV/c^2 (true mass of certain particle species; deprecated to use for invariant mass, mass from TOF etc.)");
+    VectorConfig<float>::AddField("p", ParticleFields::kP, "Full momentum of the particle, GeV/c");
+    VectorConfig<float>::AddField("E", ParticleFields::kEnergy, "Full energy of the particle, GeV");
+    VectorConfig<float>::AddField("T", ParticleFields::kKineticEnergy, "Kinetic energy of the particle, GeV");
+    VectorConfig<float>::AddField("rapidity", ParticleFields::kRapidity, "Rapidity of the particle");
+    VectorConfig<int>::AddField("q", ParticleFields::kQ, "Charge of the particle (true charge of certain particle species)");
+    VectorConfig<int>::AddField("pid", ParticleFields::kPid, "PDG code of the particle (e.g. by simulation for MC-particles or the most probable one for reconstructed particles with performed PID etc.)");
+    VectorConfig<int>::AddField("id", ParticleFields::kId, "Unique id of the particle within current event; assigned automatically (not by user)");
   } else if (type_ == DetType::kHit) {
-    VectorConfig<float>::AddField("x", HitFields::kX, "cm");
-    VectorConfig<float>::AddField("y", HitFields::kY, "cm");
-    VectorConfig<float>::AddField("z", HitFields::kZ, "cm");
-    VectorConfig<float>::AddField("phi", HitFields::kPhi, "azimuthal angle");
-    VectorConfig<float>::AddField("signal", HitFields::kSignal, "");
-    VectorConfig<int>::AddField("id", HitFields::kId, "unique id");
+    VectorConfig<float>::AddField("x", HitFields::kX, "X coordinate of the hit, cm");
+    VectorConfig<float>::AddField("y", HitFields::kY, "Y coordinate of the hit, cm");
+    VectorConfig<float>::AddField("z", HitFields::kZ, "Z coordinate of the hit, cm");
+    VectorConfig<float>::AddField("phi", HitFields::kPhi, "Azimuthal angle of the hit, rad");
+    VectorConfig<float>::AddField("signal", HitFields::kSignal, "Energy deposit collected in the hit");
+    VectorConfig<int>::AddField("id", HitFields::kId, "Unique id of the hit within current event; assigned automatically (not by user)");
   } else if (type_ == DetType::kModule) {
-    VectorConfig<int>::AddField("number", ModuleFields::kNumber, "module number");
-    VectorConfig<float>::AddField("signal", ModuleFields::kSignal, "");
-    VectorConfig<int>::AddField("id", ModuleFields::kId, "unique id");
+    VectorConfig<int>::AddField("number", ModuleFields::kNumber, "Module number");
+    VectorConfig<float>::AddField("signal", ModuleFields::kSignal, "Energy deposit collected in the module");
+    VectorConfig<int>::AddField("id", ModuleFields::kId, "Unique id of the hit within current event; assigned automatically (not by user)");
   } else if (type_ == DetType::kEventHeader) {
-    VectorConfig<float>::AddField("vtx_x", EventHeaderFields::kVertexX, "cm");
-    VectorConfig<float>::AddField("vtx_y", EventHeaderFields::kVertexY, "cm");
-    VectorConfig<float>::AddField("vtx_z", EventHeaderFields::kVertexZ, "cm");
-    VectorConfig<int>::AddField("id", EventHeaderFields::kId, "unique id");
+    VectorConfig<float>::AddField("vtx_x", EventHeaderFields::kVertexX, "X coordinate of the vertex, cm");
+    VectorConfig<float>::AddField("vtx_y", EventHeaderFields::kVertexY, "Y coordinate of the vertex, cm");
+    VectorConfig<float>::AddField("vtx_z", EventHeaderFields::kVertexZ, "Z coordinate of the vertex, cm");
+    VectorConfig<int>::AddField("id", EventHeaderFields::kId, "Always 0, this field is not used for EventHeader and is needed for compatibility with other Container types");
   }
 }
 

--- a/core/BranchConfig.hpp
+++ b/core/BranchConfig.hpp
@@ -125,7 +125,7 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
   BranchConfig& operator=(const BranchConfig&) = default;
   ~BranchConfig() override = default;
 
-  BranchConfig(std::string name, DetType type, std::string title="");
+  BranchConfig(std::string name, DetType type, std::string title = "");
 
   void Print() const override;
 

--- a/core/BranchConfig.hpp
+++ b/core/BranchConfig.hpp
@@ -125,9 +125,11 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
   BranchConfig& operator=(const BranchConfig&) = default;
   ~BranchConfig() override = default;
 
-  BranchConfig(std::string name, DetType type);
+  BranchConfig(std::string name, DetType type, std::string title="");
 
   void Print() const override;
+
+  void PrintBranchId() const;
 
   ANALYSISTREE_ATTR_NODISCARD Types GetFieldType(const std::string& sField) const;
   ANALYSISTREE_ATTR_NODISCARD ShortInt_t GetFieldId(const std::string& sField) const;
@@ -159,6 +161,8 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
     }
   }
 
+  void SetTitle(std::string title) { title_ = std::move(title); }
+
   // Getters
   template<typename T>
   ANALYSISTREE_ATTR_NODISCARD const MapType& GetMap() const { return VectorConfig<T>::GetMap(); }
@@ -166,6 +170,8 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
   ANALYSISTREE_ATTR_NODISCARD ShortInt_t GetSize() const { return VectorConfig<T>::GetSize(); }
 
   ANALYSISTREE_ATTR_NODISCARD std::string GetName() const { return name_; }
+  ANALYSISTREE_ATTR_NODISCARD std::string GetTitle() const { return title_; }
+
   template<typename T>
   ANALYSISTREE_ATTR_NODISCARD std::vector<std::string> GetFieldsNamesT() const {
     std::vector<std::string> result;
@@ -193,10 +199,11 @@ class BranchConfig : public VectorConfig<int>, public VectorConfig<float>, publi
   void GuaranteeFieldNameVacancy(const std::string& name) const;
 
   std::string name_;
+  std::string title_;
   size_t id_{0};
   DetType type_{DetType(UndefValueShort)};
 
-  ClassDefOverride(BranchConfig, 3);
+  ClassDefOverride(BranchConfig, 4);
 };
 
 // BranchConfig Merge(const BranchConfig& primary, const BranchConfig& secondary);

--- a/core/Configuration.cpp
+++ b/core/Configuration.cpp
@@ -87,6 +87,13 @@ void Configuration::Print(Option_t*) const {
   }
 }
 
+void Configuration::PrintBranchIds() const {
+  for (const auto& branch : branches_) {
+    std::cout << std::endl;
+    branch.second.PrintBranchId();
+  }
+}
+
 const std::string& Configuration::GetMatchName(const std::string& br1, const std::string& br2) const {
   auto search = matches_index_.find({br1, br2});
   if (search != matches_index_.end()) {

--- a/core/Configuration.hpp
+++ b/core/Configuration.hpp
@@ -98,6 +98,8 @@ class Configuration : public TObject {
 
   void Print(Option_t* = "") const;
 
+  void PrintBranchIds() const;
+
   static MatchingIndex MakeMatchingIndex(const std::vector<MatchingConfig>& matches) {
     MatchingIndex result;
     for (auto& match : matches) {

--- a/core/Particle.cpp
+++ b/core/Particle.cpp
@@ -14,4 +14,16 @@ void Particle::SetPid(PdgCode_t pid) {
     charge_ = GetChargeByPdgId(pid);
   }
 }
+
+void Particle::CheckIsAllowedSetMassAndChargeExplicitly() const {
+  if(!is_allowed_set_charge_and_mass_explicitly_) {
+    std::string message = "Particle::CheckIsAllowedSetMassAndChargeExplicitly(): ";
+    message += "mass and charge of the particle are set automatically with SetPid() call ";
+    message += "(unless they were already assigned with some values, incl. when copied content from Track to Particle). ";
+    message += "Use SetMass() and SetCharge() only if you want to set them different from PDG-true values. ";
+    message += "To unblock this possibility use SetIsAllowedSetMassAndChargeExplicitly() function.";
+    throw std::runtime_error(message);
+  }
+}
+
 }// namespace AnalysisTree

--- a/core/Particle.cpp
+++ b/core/Particle.cpp
@@ -16,7 +16,7 @@ void Particle::SetPid(PdgCode_t pid) {
 }
 
 void Particle::CheckIsAllowedSetMassAndChargeExplicitly() const {
-  if(!is_allowed_set_charge_and_mass_explicitly_) {
+  if (!is_allowed_set_charge_and_mass_explicitly_) {
     std::string message = "Particle::CheckIsAllowedSetMassAndChargeExplicitly(): ";
     message += "mass and charge of the particle are set automatically with SetPid() call ";
     message += "(unless they were already assigned with some values, incl. when copied content from Track to Particle). ";

--- a/core/Particle.hpp
+++ b/core/Particle.hpp
@@ -40,7 +40,7 @@ class Particle : public Track {
 
   void SetPid(PdgCode_t pid);
 
-  void SetIsAllowedSetMassAndChargeExplicitly(bool is=true) { is_allowed_set_charge_and_mass_explicitly_ = is; }
+  void SetIsAllowedSetMassAndChargeExplicitly(bool is = true) { is_allowed_set_charge_and_mass_explicitly_ = is; }
 
   void CheckIsAllowedSetMassAndChargeExplicitly() const;
 

--- a/core/Particle.hpp
+++ b/core/Particle.hpp
@@ -29,10 +29,20 @@ class Particle : public Track {
   ANALYSISTREE_ATTR_NODISCARD Floating_t GetMass() const { return mass_; }
 
   void SetMass(Floating_t mass) {
+    CheckIsAllowedSetMassAndChargeExplicitly();
     mass_ = mass;
   }
 
+  void SetCharge(Int_t charge) {
+    CheckIsAllowedSetMassAndChargeExplicitly();
+    Track::SetCharge(charge);
+  }
+
   void SetPid(PdgCode_t pid);
+
+  void SetIsAllowedSetMassAndChargeExplicitly(bool is=true) { is_allowed_set_charge_and_mass_explicitly_ = is; }
+
+  void CheckIsAllowedSetMassAndChargeExplicitly() const;
 
   ANALYSISTREE_ATTR_NODISCARD Floating_t GetEnergy() const { return sqrt(mass_ * mass_ + GetP() * GetP()); }
   ANALYSISTREE_ATTR_NODISCARD Floating_t GetKineticEnergy() const { return GetEnergy() - mass_; }
@@ -90,6 +100,7 @@ class Particle : public Track {
  protected:
   Floating_t mass_{-1000.f};
   PdgCode_t pid_{0};
+  bool is_allowed_set_charge_and_mass_explicitly_{false};//!
 
   ClassDefOverride(Particle, 2);
 };


### PR DESCRIPTION
1. Titles (descriptions) of default fields are made more precise and informative.
2. Added a title to Branch (similarly to that of Field) - for detailed description of branch.
3. SetMass() and SetCharge() for Particle are made more safe - user can call them only if explicitly unlocks this possibility. Otherwise one should call SetPid(), and charge with mass will be set automatically.
4. AnalysisTreeDiff.patch file (see PR [#127](https://github.com/HeavyIonAnalysis/AnalysisTree/pull/127)) is set to be update in each build-install action, even if it is empty (to avoid misleading remnant AnalysisTreeDiff.patch file from the previous building).