### PR TITLE
HelperFunctions

### DIFF
--- a/core/Constants.hpp
+++ b/core/Constants.hpp
@@ -30,10 +30,11 @@ typedef UInt_t UInteger_t;
 typedef Short_t ShortInt_t;
 typedef Long64_t PdgCode_t;
 
-constexpr Floating_t UndefValueFloat = -999.;
+constexpr Floating_t UndefValueFloat = -999.f;
 constexpr ShortInt_t UndefValueShort = -999;
 constexpr Integer_t UndefValueInt = -999;
 constexpr double SmallNumber = 1e-6;
+constexpr double HugeNumber = 1e9;
 
 namespace Exyz {
 enum Exyz : ShortInt_t {

--- a/infra/CMakeLists.txt
+++ b/infra/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SOURCES
 message(STATUS "CMAKE_PROJECT_NAME ${CMAKE_PROJECT_NAME}")
 
 string(REPLACE ".cpp" ".hpp" HEADERS "${SOURCES}")
-list(APPEND HEADERS "VariantMagic.hpp" "ToyMC.hpp" "Utils.hpp" "BranchHashHelper.hpp")
+list(APPEND HEADERS "VariantMagic.hpp" "ToyMC.hpp" "Utils.hpp" "BranchHashHelper.hpp" "HelperFunctions.hpp")
 
 include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR} $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
 add_library(AnalysisTreeInfra SHARED ${SOURCES} G__AnalysisTreeInfra.cxx)

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -1,0 +1,30 @@
+#ifndef ANALYSISTREE_INFRA_HELPER_FUNCTIONS_HPP
+#define ANALYSISTREE_INFRA_HELPER_FUNCTIONS_HPP
+
+#include "SimpleCut.hpp"
+
+#include <string>
+#include <vector>
+
+namespace HelperFunctions {
+
+template<typename T>
+inline std::string ToStringWithPrecision(const T a_value, const int n) {
+  std::ostringstream out;
+  out.precision(n);
+  out << std::fixed << a_value;
+  return out.str();
+}
+
+inline std::vector<AnalysisTree::SimpleCut> CreateSliceCuts(const std::vector<float>& ranges, const std::string& cutNamePrefix, const std::string& branchFieldName) {
+  std::vector<AnalysisTree::SimpleCut> sliceCuts;
+  for(int iRange=0; iRange<ranges.size()-1; iRange++) {
+    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), 2) + "_" + ToStringWithPrecision(ranges.at(iRange+1), 2);
+    sliceCuts.emplace_back(AnalysisTree::RangeCut(branchFieldName, ranges.at(iRange), ranges.at(iRange+1), cutName));
+  }
+
+  return sliceCuts;
+}
+
+}
+#endif // ANALYSISTREE_INFRA_HELPER_FUNCTIONS_HPP


### PR DESCRIPTION
1. Added a header for functions which are often used in AnalysisTree based macros and ATQA tasks in order to avoid their repetition in every new piece of code. Currently 2 functions are present, however it can be extended.
2. Added a constant `HugeNumber` for effective cuts switching off (releasing).