### PR TITLE
Enable AT tasks running from examples directory

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(EXECUTABLES
+        example
+        run_read_task
+        run_write_task
+)
+
 set(SOURCES
         UserTaskWrite.cpp
         UserTaskRead.cpp
@@ -28,47 +34,39 @@ target_link_libraries(AnalysisTreeUser
 include(${ROOT_USE_FILE})
 include_directories(${ROOT_INCLUDE_DIR} ${ROOT_INCLUDE_DIRS} ${AnalysisTree_INCLUDE_DIR})
 
-add_executable(example example.cpp)
-target_link_libraries(example AnalysisTreeBase AnalysisTreeInfra AnalysisTreeUser ${ROOT_LIBRARIES} EG)
+install(TARGETS AnalysisTreeUser EXPORT AnalysisTreeTargets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include/AnalysisTree
+)
 
-add_executable(run_read_task run_read_task.cpp)
-target_link_libraries(run_read_task AnalysisTreeBase AnalysisTreeInfra AnalysisTreeUser ${ROOT_LIBRARIES} EG)
+install(FILES
+        ${HEADERS}
+        DESTINATION
+        include/AnalysisTree
+        COMPONENT
+        Devel
+)
 
+set(PCM_FILE_NAME libAnalysisTreeUser)
 
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${PCM_FILE_NAME}_rdict.pcm"
+        DESTINATION
+        lib
+        OPTIONAL
+)
 
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${PCM_FILE_NAME}.rootmap"
+        DESTINATION
+        lib
+        OPTIONAL
+)
 
-
-
-#cmake_minimum_required(VERSION 3.5)
-#project(AnalysisTreeTask CXX)
-#set(PROJECT_VERSION 1.0)
-#
-#if(NOT DEFINED CMAKE_BUILD_TYPE)
-#    set(CMAKE_BUILD_TYPE RELEASE)
-#endif()
-#
-#if(NOT DEFINED CMAKE_CXX_STANDARD)
-#    set(CMAKE_CXX_STANDARD 17)
-#endif()
-#
-## in DEBUG mode make verbose Makefile
-#if (CMAKE_BUILD_TYPE MATCHES DEBUG)
-#    set(CMAKE_VERBOSE_MAKEFILE ON)
-#endif ()
-#
-#if(CMAKE_CXX_STANDARD LESS 17)
-#    find_package(Boost)
-#endif()
-#
-#if(Boost_FOUND)
-#    message(STATUS "Boost version ${Boost_VERSION_STRING} is found!")
-#    message(STATUS "Boost include dir: ${Boost_INCLUDE_DIRS}")
-#    add_definitions(-DUSEBOOST)
-#endif()
-#
-#find_package(ROOT REQUIRED)
-#list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
-#find_package(AnalysisTree REQUIRED)
-#
-#message(STATUS "${ROOT_INCLUDE_DIRS} ${AnalysisTree_INCLUDE_DIR}")
-#message(STATUS "${ROOT_LIBRARIES} ${AnalysisTree_INCLUDE_DIR}")
+foreach(EXE ${EXECUTABLES})
+        add_executable(${EXE} ${EXE}.cpp)
+        target_link_libraries(${EXE} AnalysisTreeBase AnalysisTreeInfra AnalysisTreeUser ${ROOT_LIBRARIES} EG)
+        install (TARGETS ${EXE} RUNTIME DESTINATION bin)
+endforeach()

--- a/examples/UserTaskRead.cpp
+++ b/examples/UserTaskRead.cpp
@@ -11,8 +11,8 @@ void UserTaskRead::Init() {
   AddInputBranch("SimParticles");
   AddInputBranch("VtxTracks");
 
-  particles_ = chain->GetBranch("SimParticles");
-  tracks_ = chain->GetBranch("VtxTracks");
+  particles_ = chain->GetBranchObject("SimParticles");
+  tracks_ = chain->GetBranchObject("VtxTracks");
   match_ = chain->GetMatching("VtxTracks", "SimParticles");
 }
 

--- a/examples/UserTaskWrite.cpp
+++ b/examples/UserTaskWrite.cpp
@@ -9,7 +9,7 @@ void UserTaskWrite::Init() {
   auto chain = man->GetChain();
 
   AddInputBranch("SimParticles");
-  particles_ = chain->GetBranch("SimParticles");
+  particles_ = chain->GetBranchObject("SimParticles");
 
   auto br_conf = chain->GetConfiguration()->GetBranchConfig("SimParticles");
   auto new_conf = br_conf.Clone("NewParticles", DetType::kParticle);
@@ -18,6 +18,7 @@ void UserTaskWrite::Init() {
 
   new_particles_ = Branch(new_conf);
   new_particles_.SetMutable();
+  particles_.Freeze();
   man->AddBranch(&new_particles_);
 }
 

--- a/examples/run_read_task.cpp
+++ b/examples/run_read_task.cpp
@@ -13,7 +13,7 @@ int main(int argc, char* argv[]) {
 
   if (argc < 3) {
     std::cout << "Error! Please use " << std::endl;
-    std::cout << " ./example filelist treename" << std::endl;
+    std::cout << " ./run_read_task filelist treename" << std::endl;
     exit(EXIT_FAILURE);
   }
 

--- a/examples/run_write_task.cpp
+++ b/examples/run_write_task.cpp
@@ -1,0 +1,36 @@
+/* Copyright (C) 2025 GSI, Heidelberg University
+SPDX-License-Identifier: GPL-3.0-only
+Authors: Oleksii Lubynets, Ilya Selyuzhenkov */
+#include "UserTaskWrite.hpp"
+#include <TaskManager.hpp>
+
+using namespace AnalysisTree;
+
+void run_write_task(const std::string& filelist, const std::string& treename);
+
+int main(int argc, char* argv[]) {
+  if (argc < 3) {
+    std::cout << "Error! Please use " << std::endl;
+    std::cout << " ./run_write_task filelist treename" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  const std::string filelist = argv[1];
+  const std::string treename = argv[2];
+  run_write_task(filelist, treename);
+
+  return 0;
+}
+
+void run_write_task(const std::string& filelist, const std::string& treename) {
+  auto* man = TaskManager::GetInstance();
+  man->SetOutputName("UTW_output.root", "aTree");
+  man->SetWriteMode(eBranchWriteMode::kCopyTree);
+
+  auto* task = new UserTaskWrite();
+  man->AddTask(task);
+
+  man->Init({filelist}, {treename});
+  man->Run(2);
+  man->Finish();
+}

--- a/infra/Branch.hpp
+++ b/infra/Branch.hpp
@@ -102,12 +102,18 @@ class Branch {
 
   /* Checks are used very often */
   inline void CheckFrozen(bool expected = true) const {
-    if (is_frozen_ != expected)
-      throw std::runtime_error("Branch is frozen");
+    if (is_frozen_ != expected) {
+      const std::string prefix = expected ? "un" : "";
+      const std::string message = "Branch " + config_.GetName() + " is " + prefix + "frozen while the opposite was expected";
+      throw std::runtime_error(message);
+    }
   }
   inline void CheckMutable(bool expected = true) const {
-    if (is_mutable_ != expected)
-      throw std::runtime_error("Branch is not mutable");
+    if (is_mutable_ != expected) {
+      const std::string prefix = expected ? "im" : "";
+      const std::string message = "Branch " + config_.GetName() + " is " + prefix + "mutable while the opposite was expected";
+      throw std::runtime_error(message);
+    }
   }
   /**
    * @brief Gets variables according to variable names specified in the arguments.


### PR DESCRIPTION
1. `examples` directory brought to more order. Now one can easily add new AT-based tasks by placing the `.cpp` file into `examples` directory and adding a proper name in `examples/CMakeLists.txt`, field `EXECUTABLES`.
2. Minor cosmetic changes:
- avoid deprecated function `Chain::GetBranch() `usage;
- provide more precise and informative output in `Branch::CheckFrozen()` and `Branch::CheckMutable()` functions.