### PR TITLE
Enable PlainTreeFiller::SetFieldsToIgnore() for all default fields

### DIFF
--- a/infra/PlainTreeFiller.cpp
+++ b/infra/PlainTreeFiller.cpp
@@ -25,6 +25,18 @@ void PlainTreeFiller::SetFieldsToIgnore(const std::vector<std::string>&& fields_
 }
 
 void PlainTreeFiller::Init() {
+  if (is_ignore_defual_fields_) {
+    std::vector<std::string> defaultFieldsNames;
+    auto mapF = config_->GetBranchConfig(branch_name_).GetMap<float>();
+    auto mapI = config_->GetBranchConfig(branch_name_).GetMap<int>();
+    auto mapB = config_->GetBranchConfig(branch_name_).GetMap<bool>();
+    for (auto& m : {mapF, mapI, mapB}) {
+      for (auto& me : m) {
+        if (me.second.id_ < 0) defaultFieldsNames.emplace_back(me.first);
+      }
+    }
+    SetFieldsToIgnore(std::move(defaultFieldsNames));
+  }
 
   if (!branch_name_.empty()) {
     const auto& branch_config = config_->GetBranchConfig(branch_name_);

--- a/infra/PlainTreeFiller.hpp
+++ b/infra/PlainTreeFiller.hpp
@@ -29,6 +29,8 @@ class PlainTreeFiller : public AnalysisTask {
 
   void SetFieldsToIgnore(const std::vector<std::string>&& fields_to_ignore);
 
+  void SetIsIgnoreDefaultFields(bool is = true) { is_ignore_defual_fields_ = is; }
+
  protected:
   TFile* file_{nullptr};
   TTree* plain_tree_{nullptr};
@@ -39,6 +41,8 @@ class PlainTreeFiller : public AnalysisTask {
 
   std::vector<float> vars_{};
   std::vector<std::string> fields_to_ignore_{};
+
+  bool is_ignore_defual_fields_{false};
 };
 
 }// namespace AnalysisTree


### PR DESCRIPTION
See PR https://github.com/HeavyIonAnalysis/AnalysisTree/pull/111, now the set of all default fields (with negative ids) can be excluded from conversion into a plain tree.