### PR TITLE
Extend possible ways of Cuts construction: AddCut(s)

### DIFF
--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -77,4 +77,27 @@ bool Cuts::Apply(const BranchChannel& ob) const {
   return true;
 }
 
+void Cuts::AddCut(const SimpleCut& cut) {
+  cuts_.emplace_back(cut);
+  branch_names_.insert(cut.GetBranches().begin(), cut.GetBranches().end());
+}
+
+void Cuts::AddCuts(const std::vector<SimpleCut>& cuts) {
+  for(auto& cut : cuts) {
+    AddCut(cut);
+  }
+}
+
+template<typename... Args>
+Cuts::Cuts(std::string name, Args... args) : name_(std::move(name)) {
+//  AddCuts(std::forward<Args>(args)...);
+  AddCuts(args...);
+}
+
+template<typename T, typename... Args>
+void Cuts::AddCuts(const T& t, const Args&... args) {
+  AddCuts(t);
+  AddCuts(args...);
+}
+
 }// namespace AnalysisTree

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -83,7 +83,7 @@ void Cuts::AddCut(const SimpleCut& cut) {
 }
 
 void Cuts::AddCuts(const std::vector<SimpleCut>& cuts) {
-  for(auto& cut : cuts) {
+  for (auto& cut : cuts) {
     AddCut(cut);
   }
 }

--- a/infra/Cuts.cpp
+++ b/infra/Cuts.cpp
@@ -88,16 +88,4 @@ void Cuts::AddCuts(const std::vector<SimpleCut>& cuts) {
   }
 }
 
-template<typename... Args>
-Cuts::Cuts(std::string name, Args... args) : name_(std::move(name)) {
-//  AddCuts(std::forward<Args>(args)...);
-  AddCuts(args...);
-}
-
-template<typename T, typename... Args>
-void Cuts::AddCuts(const T& t, const Args&... args) {
-  AddCuts(t);
-  AddCuts(args...);
-}
-
 }// namespace AnalysisTree

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -48,15 +48,27 @@ class Cuts {
     }
   }
 
-  template<typename... Args>
-  explicit Cuts(std::string name, Args... args);
-
   void AddCut(const SimpleCut& cut);
 
   void AddCuts(const std::vector<SimpleCut>& cuts);
 
+  // Base case for variadic recursion (handles when there's just one argument left)
+  template<typename T>
+  void AddCuts(const T& t) {
+    AddCuts(t);  // Call the appropriate overload for a single argument (like std::vector<SimpleCut>)
+  }
+
+  // Recursive case for variadic template (multiple arguments)
   template<typename T, typename... Args>
-  void AddCuts(const T& t, const Args&... args);
+  void AddCuts(const T& t, const Args&... args) {
+    AddCuts(t);
+    AddCuts(args...);
+  }
+
+  template<typename... Args>
+  Cuts(std::string name, Args... args) : name_(std::move(name)) {
+    AddCuts(args...);
+  }
 
   /**
    * @brief Evaluates all SimpleCuts

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -48,6 +48,16 @@ class Cuts {
     }
   }
 
+  template<typename... Args>
+  explicit Cuts(std::string name, Args... args);
+
+  void AddCut(const SimpleCut& cut);
+
+  void AddCuts(const std::vector<SimpleCut>& cuts);
+
+  template<typename T, typename... Args>
+  void AddCuts(const T& t, const Args&... args);
+
   /**
    * @brief Evaluates all SimpleCuts
    * @tparam T type of data-object associated with TTree

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -52,23 +52,23 @@ class Cuts {
 
   void AddCuts(const std::vector<SimpleCut>& cuts);
 
-  // Base case for variadic recursion (handles when there's just one argument left)
-  template<typename T>
-  void AddCuts(const T& t) {
-    AddCuts(t);  // Call the appropriate overload for a single argument (like std::vector<SimpleCut>)
-  }
-
-  // Recursive case for variadic template (multiple arguments)
-  template<typename T, typename... Args>
-  void AddCuts(const T& t, const Args&... args) {
-    AddCuts(t);
-    AddCuts(args...);
-  }
-
-  template<typename... Args>
-  Cuts(std::string name, Args... args) : name_(std::move(name)) {
-    AddCuts(args...);
-  }
+//  // Base case for variadic recursion (handles when there's just one argument left)
+//  template<typename T>
+//  void AddCuts(const T& t) {
+//    AddCuts(t);  // Call the appropriate overload for a single argument (like std::vector<SimpleCut>)
+//  }
+//
+//  // Recursive case for variadic template (multiple arguments)
+//  template<typename T, typename... Args>
+//  void AddCuts(const T& t, const Args&... args) {
+//    AddCuts(t);
+//    AddCuts(args...);
+//  }
+//
+//  template<typename... Args> // TODO this constructor hangs. Needs debugging
+//  Cuts(std::string name, Args... args) : name_(std::move(name)) {
+//    AddCuts(args...);
+//  }
 
   /**
    * @brief Evaluates all SimpleCuts

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -52,23 +52,23 @@ class Cuts {
 
   void AddCuts(const std::vector<SimpleCut>& cuts);
 
-//  // Base case for variadic recursion (handles when there's just one argument left)
-//  template<typename T>
-//  void AddCuts(const T& t) {
-//    AddCuts(t);  // Call the appropriate overload for a single argument (like std::vector<SimpleCut>)
-//  }
-//
-//  // Recursive case for variadic template (multiple arguments)
-//  template<typename T, typename... Args>
-//  void AddCuts(const T& t, const Args&... args) {
-//    AddCuts(t);
-//    AddCuts(args...);
-//  }
-//
-//  template<typename... Args> // TODO this constructor hangs. Needs debugging
-//  Cuts(std::string name, Args... args) : name_(std::move(name)) {
-//    AddCuts(args...);
-//  }
+  //  // Base case for variadic recursion (handles when there's just one argument left)
+  //  template<typename T>
+  //  void AddCuts(const T& t) {
+  //    AddCuts(t);  // Call the appropriate overload for a single argument (like std::vector<SimpleCut>)
+  //  }
+  //
+  //  // Recursive case for variadic template (multiple arguments)
+  //  template<typename T, typename... Args>
+  //  void AddCuts(const T& t, const Args&... args) {
+  //    AddCuts(t);
+  //    AddCuts(args...);
+  //  }
+  //
+  //  template<typename... Args> // TODO this constructor hangs. Needs debugging
+  //  Cuts(std::string name, Args... args) : name_(std::move(name)) {
+  //    AddCuts(args...);
+  //  }
 
   /**
    * @brief Evaluates all SimpleCuts

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -18,13 +18,13 @@ inline std::string ToStringWithPrecision(const T a_value, const int n) {
 
 inline std::vector<AnalysisTree::SimpleCut> CreateSliceCuts(const std::vector<float>& ranges, const std::string& cutNamePrefix, const std::string& branchFieldName) {
   std::vector<AnalysisTree::SimpleCut> sliceCuts;
-  for(int iRange=0; iRange<ranges.size()-1; iRange++) {
-    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), 2) + "_" + ToStringWithPrecision(ranges.at(iRange+1), 2);
-    sliceCuts.emplace_back(AnalysisTree::RangeCut(branchFieldName, ranges.at(iRange), ranges.at(iRange+1), cutName));
+  for (int iRange = 0; iRange < ranges.size() - 1; iRange++) {
+    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), 2) + "_" + ToStringWithPrecision(ranges.at(iRange + 1), 2);
+    sliceCuts.emplace_back(AnalysisTree::RangeCut(branchFieldName, ranges.at(iRange), ranges.at(iRange + 1), cutName));
   }
 
   return sliceCuts;
 }
 
-}
-#endif // ANALYSISTREE_INFRA_HELPER_FUNCTIONS_HPP
+}// namespace HelperFunctions
+#endif// ANALYSISTREE_INFRA_HELPER_FUNCTIONS_HPP

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -43,6 +43,14 @@ class SimpleCut {
     FillBranchNames();
   }
 
+  SimpleCut(const std::vector<Variable>& vars, std::function<bool(std::vector<double>&)> lambda, std::string title = "") : title_(std::move(title)),
+                                                                                                                           lambda_(std::move(lambda)) {
+    for(auto& var : vars) {
+      vars_.emplace_back(var);
+    }
+    FillBranchNames();
+  }
+
   /**
   * Constructor for range cut: min <= field <= max
   * @param variable_name name of the variable in format "branch.field"

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -45,7 +45,7 @@ class SimpleCut {
 
   SimpleCut(const std::vector<Variable>& vars, std::function<bool(std::vector<double>&)> lambda, std::string title = "") : title_(std::move(title)),
                                                                                                                            lambda_(std::move(lambda)) {
-    for(auto& var : vars) {
+    for (auto& var : vars) {
       vars_.emplace_back(var);
     }
     FillBranchNames();

--- a/infra/TaskManager.cpp
+++ b/infra/TaskManager.cpp
@@ -22,6 +22,7 @@ TaskManager* TaskManager::GetInstance() {
 
 void TaskManager::Init(const std::vector<std::string>& filelists, const std::vector<std::string>& in_trees) {
   assert(!is_init_);
+  std::cout << "TaskManager::Init()\n";
   is_init_ = true;
   read_in_tree_ = true;
   chain_ = new Chain(filelists, in_trees);
@@ -51,6 +52,7 @@ void TaskManager::InitTasks() {
 
 void TaskManager::Init() {
   assert(!is_init_);
+  std::cout << "TaskManager::Init()\n";
   is_init_ = true;
   fill_out_tree_ = true;
 


### PR DESCRIPTION
Added functions `Cuts::AddCut()` and` Cuts::AddCuts()` which allow for adding `SimpleCut(`s) to already existing `Cuts` object (no need to create `Cuts` object again).
Tried to enable `Cuts` constructon with variadic list of `SimpleCut`s however not succeed yet (the constructor hangs when called). To be fixed.