### PR TITLE
Improve SimpleCut comparison

### DIFF
--- a/core/Particle.test.cpp
+++ b/core/Particle.test.cpp
@@ -8,6 +8,8 @@
 
 #include "Particle.hpp"
 
+#include "TDatabasePDG.h"
+
 namespace {
 
 using namespace AnalysisTree;
@@ -28,7 +30,7 @@ TEST(Particle, Basics) {
   EXPECT_EQ(particle.GetSize<bool>(), 0);
 
   EXPECT_EQ(particle.GetPid(), 211);
-  EXPECT_FLOAT_EQ(particle.GetMass(), 0.13957);
+  EXPECT_FLOAT_EQ(particle.GetMass(), TDatabasePDG::Instance()->GetParticle(211)->Mass());
 }
 }// namespace
 

--- a/infra/Chain.cpp
+++ b/infra/Chain.cpp
@@ -37,6 +37,7 @@ void Chain::InitChain() {
 
   TFileCollection fc("fc", "", filelists_[0].c_str());
   this->AddFileInfoList(reinterpret_cast<TCollection*>(fc.GetList()));
+  this->ls();
 
   std::vector<std::string> aliases;
   aliases.reserve(treenames_.size());

--- a/infra/Cuts.hpp
+++ b/infra/Cuts.hpp
@@ -52,24 +52,6 @@ class Cuts {
 
   void AddCuts(const std::vector<SimpleCut>& cuts);
 
-  //  // Base case for variadic recursion (handles when there's just one argument left)
-  //  template<typename T>
-  //  void AddCuts(const T& t) {
-  //    AddCuts(t);  // Call the appropriate overload for a single argument (like std::vector<SimpleCut>)
-  //  }
-  //
-  //  // Recursive case for variadic template (multiple arguments)
-  //  template<typename T, typename... Args>
-  //  void AddCuts(const T& t, const Args&... args) {
-  //    AddCuts(t);
-  //    AddCuts(args...);
-  //  }
-  //
-  //  template<typename... Args> // TODO this constructor hangs. Needs debugging
-  //  Cuts(std::string name, Args... args) : name_(std::move(name)) {
-  //    AddCuts(args...);
-  //  }
-
   /**
    * @brief Evaluates all SimpleCuts
    * @tparam T type of data-object associated with TTree
@@ -106,6 +88,8 @@ class Cuts {
 
   ANALYSISTREE_ATTR_NODISCARD std::set<size_t> GetBranchIds() const { return branch_ids_; }
   ANALYSISTREE_ATTR_NODISCARD const std::string& GetName() const { return name_; }
+
+  void SetName(const std::string& name) { name_ = name; }
 
   std::vector<SimpleCut>& GetCuts() { return cuts_; }
 

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -16,11 +16,34 @@ inline std::string ToStringWithPrecision(const T a_value, const int n) {
   return out.str();
 }
 
-inline std::vector<AnalysisTree::SimpleCut> CreateSliceCuts(const std::vector<float>& ranges, const std::string& cutNamePrefix, const std::string& branchFieldName) {
+template<typename T>
+inline std::string ToStringWithSignificantFigures(const T a_value, const int n) {
+  if(a_value == 0) return "0";
+
+  const double dMag = std::log10(std::abs(a_value)); // scale of the a_value (e.g 1.* for 1.2345, 2.* for 12.345 etc)
+  const int iMag = static_cast<int>(dMag-n+1 > 0 ? dMag-n+1 : dMag-n);
+  const T shifted_value = a_value/std::pow(10, iMag); // shift decimal point to have all required digits to l.h.s. from it
+  const T rounded_value = static_cast<T>(std::round(shifted_value)); // get rid of r.h.s. from decimal point
+  const T reshifted_value = rounded_value*std::pow(10, iMag); // return decimal point to its original place
+  const int precision = iMag < 0 ? -iMag : 0; // determine how many digits after decimal point one needs
+  return ToStringWithPrecision(reshifted_value, precision);
+}
+
+inline std::vector<AnalysisTree::SimpleCut> CreateRangeCuts(const std::vector<float>& ranges, const std::string& cutNamePrefix, const std::string& branchFieldName, int precision=2) {
   std::vector<AnalysisTree::SimpleCut> sliceCuts;
   for (int iRange = 0; iRange < ranges.size() - 1; iRange++) {
-    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), 2) + "_" + ToStringWithPrecision(ranges.at(iRange + 1), 2);
+    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), 2) + "_" + ToStringWithPrecision(ranges.at(iRange + 1), precision);
     sliceCuts.emplace_back(AnalysisTree::RangeCut(branchFieldName, ranges.at(iRange), ranges.at(iRange + 1), cutName));
+  }
+
+  return sliceCuts;
+}
+
+inline std::vector<AnalysisTree::SimpleCut> CreateEqualCuts(const std::vector<float>& values, const std::string& cutNamePrefix, const std::string& branchFieldName, int precision=2) {
+  std::vector<AnalysisTree::SimpleCut> sliceCuts;
+  for (int iValue = 0; iValue < values.size(); iValue++) {
+    const std::string cutName = cutNamePrefix + ToStringWithPrecision(values.at(iValue), precision);
+    sliceCuts.emplace_back(AnalysisTree::EqualsCut(branchFieldName, values.at(iValue), cutName));
   }
 
   return sliceCuts;

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -3,6 +3,7 @@
 
 #include "SimpleCut.hpp"
 
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/infra/SimpleCut.hpp
+++ b/infra/SimpleCut.hpp
@@ -41,6 +41,7 @@ class SimpleCut {
                    [](const std::string& arg_name) { return Variable::FromString(arg_name); });
 
     FillBranchNames();
+    hash_ = 1; // Impossible to calculate for lambda_
   }
 
   SimpleCut(const std::vector<Variable>& vars, std::function<bool(std::vector<double>&)> lambda, std::string title = "") : title_(std::move(title)),
@@ -49,6 +50,7 @@ class SimpleCut {
       vars_.emplace_back(var);
     }
     FillBranchNames();
+    hash_ = 1; // Impossible to calculate for lambda_
   }
 
   /**
@@ -121,6 +123,7 @@ class SimpleCut {
   std::vector<Variable> vars_{};
   std::set<std::string> branch_names_{};
   std::function<bool(std::vector<double>&)> lambda_;///< function used to evaluate the cut.
+  size_t hash_;
 
   ClassDef(SimpleCut, 1);
 };

--- a/infra/SimpleCut.test.cpp
+++ b/infra/SimpleCut.test.cpp
@@ -7,9 +7,57 @@
 #include "SimpleCut.hpp"
 #include <gtest/gtest.h>
 
+#include <vector>
+
 namespace {
 
 using namespace AnalysisTree;
+
+TEST(SimpleCut, Basics) {
+  SimpleCut ecut1 = EqualsCut(Variable::FromString("BranchName.FieldName"), 1);
+  SimpleCut ecut1same = EqualsCut(Variable::FromString("BranchName.FieldName"), 1);
+  SimpleCut ecut2 = EqualsCut(Variable::FromString("BranchName.FieldName"), 2);
+  SimpleCut ecut3 = EqualsCut(Variable::FromString("BranchName3.FieldName3"), 1);
+  SimpleCut ecut1copy = ecut1;
+  SimpleCut& ecut1ref = ecut1;
+
+  EXPECT_TRUE(ecut1 == ecut1);
+  EXPECT_TRUE(ecut1 == ecut1same);
+  EXPECT_TRUE(ecut1 == ecut1copy);
+  EXPECT_TRUE(ecut1 == ecut1ref);
+  EXPECT_FALSE(ecut1 == ecut2);
+  EXPECT_FALSE(ecut1 == ecut3);
+  EXPECT_FALSE(ecut2 == ecut3);
+  
+  SimpleCut rcut1 = RangeCut(Variable::FromString("BranchName.FieldName"), 1, 2);
+  SimpleCut rcut1same = RangeCut(Variable::FromString("BranchName.FieldName"), 1, 2);
+  SimpleCut rcut2 = RangeCut(Variable::FromString("BranchName.FieldName"), 2, 5);
+  SimpleCut rcut3 = RangeCut(Variable::FromString("BranchName3.FieldName3"), 1, 2);
+  SimpleCut rcut1copy = rcut1;
+  SimpleCut& rcut1ref = rcut1;
+  
+  EXPECT_TRUE(rcut1 == rcut1);
+  EXPECT_TRUE(rcut1 == rcut1same);
+  EXPECT_TRUE(rcut1 == rcut1copy);
+  EXPECT_TRUE(rcut1 == rcut1ref);
+  EXPECT_FALSE(rcut1 == rcut2);
+  EXPECT_FALSE(rcut1 == rcut3);
+  EXPECT_FALSE(rcut2 == rcut3);
+
+  SimpleCut lcut1 = SimpleCut((std::vector<std::string>){"B1.f1", "B2.f2", "B3.f3"}, [](std::vector<double> par){ return par[0]/par[1]*par[2] < 10; });
+  SimpleCut lcut1same = SimpleCut((std::vector<std::string>){"B1.f1", "B2.f2", "B3.f3"}, [](std::vector<double> par){ return par[0]/par[1]*par[2] < 10; });
+  SimpleCut lcut2 = SimpleCut((std::vector<std::string>){"B11.f11", "B22.f22", "B33.f33"}, [](std::vector<double> par){ return par[0]/par[1]*par[2] < 5; });
+  SimpleCut lcut1copy = lcut1;
+  SimpleCut& lcut1ref = lcut1;
+
+  EXPECT_TRUE(lcut1 == lcut1);
+  EXPECT_FALSE(lcut1 == lcut1same); // it should not be like that, but this is a concession
+  EXPECT_FALSE(lcut1 == lcut1copy); // it should not be like that, but this is a concession
+  EXPECT_TRUE(lcut1 == lcut1ref);
+  EXPECT_FALSE(lcut1 == lcut2);
+  EXPECT_FALSE(lcut1 == ecut1);
+  EXPECT_FALSE(lcut1 == rcut1);
+}
 
 }
 


### PR DESCRIPTION
**Major change:**
Before `SimpleCut` comparison (`==` operator) was done in the following way: if their names and lists of variables coincide the `SimpleCut`s are assumed to be equal. And the logic of the `SimpleCut` implemented in the function object (lambda function) was not compared. It lead to a bug when using AnalysisTreeQA package: because of false equality of `Cuts` the histograms supposed to be built with different cuts were built with the same - that one which was declared first.
Now this issue is partially addressed in the following way:
each `SimpleCut` created as `EqualsCut` or `RangeCut` has a hash generated from concatenation of its name, list of variables and numbers to be cutted. If two `SimpleCut`s have different hashes they are assumed non-equal. However if the `SimpleCut` is initialized with lambda function, its unique hash cannot be evaluated, therefore any pair of `SimpleCut`s initialized with lambdas are assumed not equal (unless they are in the same memory place). From the considerations expressed above (about AnalysisTreeQA package) it is less critical to identify cuts false non-equal than false-equal.

**Minor changes:**
1. Added functions to `HelperFunctions.hpp`
2. Added tests for `SimpleCut`, covering issues discussed above
3. Printed out the list of files in the filelist when initializing `AnalysisTree::Chain`