### PR TITLE
Generic container

### DIFF
--- a/core/AnalysisTreeCoreLinkDef.h
+++ b/core/AnalysisTreeCoreLinkDef.h
@@ -40,6 +40,7 @@
 #pragma link C++ typedef AnalysisTree::ModuleDetector;
 #pragma link C++ typedef AnalysisTree::HitDetector;
 #pragma link C++ typedef AnalysisTree::ModulePositions;
+#pragma link C++ typedef AnalysisTree::GenericDetector;
 
 #pragma link C++ defined_in "Constants.h";
 

--- a/core/Constants.hpp
+++ b/core/Constants.hpp
@@ -49,7 +49,8 @@ enum class DetType : ShortInt_t {
   kModule,
   kTrack,
   kEventHeader,
-  kParticle
+  kParticle,
+  kGeneric
 };
 
 enum class Types : ShortInt_t {

--- a/examples/AnalysisTreeUserLinkDef.h
+++ b/examples/AnalysisTreeUserLinkDef.h
@@ -4,7 +4,7 @@
 #pragma link off all functions;
 #pragma link C++ nestedclasses;
 
-//#pragma link C++ class UserTaskRead++;
-#pragma link C++ class UserTaskWrite++;
+#pragma link C++ class UserTaskRead+;
+#pragma link C++ class UserTaskWrite+;
 
 #endif

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,8 +13,8 @@ message(STATUS "CMAKE_PROJECT_NAME ${CMAKE_PROJECT_NAME}")
 
 string(REPLACE ".cpp" ".hpp" HEADERS "${SOURCES}")
 
-include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_SOURCE_DIR}/infra ${CMAKE_CURRENT_SOURCE_DIR} $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
 add_library(AnalysisTreeUser SHARED ${SOURCES} G__AnalysisTreeUser.cxx)
+target_include_directories(AnalysisTreeUser PRIVATE ${CMAKE_SOURCE_DIR}/core ${CMAKE_SOURCE_DIR}/infra ${CMAKE_CURRENT_SOURCE_DIR} $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
 target_compile_definitions(AnalysisTreeUser PUBLIC
         $<$<BOOL:${Boost_FOUND}>:ANALYSISTREE_BOOST_FOUND>)
 

--- a/examples/UserTaskRead.hpp
+++ b/examples/UserTaskRead.hpp
@@ -1,7 +1,7 @@
 #ifndef ANALYSISTREE_EXAMPLES_USERTASKREAD_HPP_
 #define ANALYSISTREE_EXAMPLES_USERTASKREAD_HPP_
 
-#include <Task.hpp>
+#include <AnalysisTree/Task.hpp>
 
 class UserTaskRead : public AnalysisTree::Task {
 

--- a/examples/UserTaskWrite.hpp
+++ b/examples/UserTaskWrite.hpp
@@ -1,9 +1,9 @@
 #ifndef ANALYSISTREE_EXAMPLES_USERTASKWRITE_HPP_
 #define ANALYSISTREE_EXAMPLES_USERTASKWRITE_HPP_
 
-#include <Branch.hpp>
 #include <Detector.hpp>
-#include <Task.hpp>
+#include <AnalysisTree/Branch.hpp>
+#include <AnalysisTree/Task.hpp>
 
 class UserTaskWrite : public AnalysisTree::Task {
 

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -33,7 +33,7 @@ void example(const std::string& filename, const std::string& treename){
   data_header->Print();
   config->Print();
 
-  auto rec_particles = chain->GetBranch("VtxTracks");
+  auto rec_particles = chain->GetBranchObject("VtxTracks");
   auto rec2sim_particles = chain->GetMatching("VtxTracks", "SimParticles");
 
   auto rec_pT = rec_particles.GetField("pT");

--- a/infra/Branch.cpp
+++ b/infra/Branch.cpp
@@ -41,6 +41,10 @@ void Branch::InitDataPtr() {
       data_ = temp;
       break;
     }
+    case DetType::kGeneric: {
+      data_ = new GenericDetector(config_.GetId());
+      break;
+    }
     default: throw std::runtime_error("Branch type is not known!");
   }
 }

--- a/infra/CMakeLists.txt
+++ b/infra/CMakeLists.txt
@@ -21,8 +21,8 @@ message(STATUS "CMAKE_PROJECT_NAME ${CMAKE_PROJECT_NAME}")
 string(REPLACE ".cpp" ".hpp" HEADERS "${SOURCES}")
 list(APPEND HEADERS "VariantMagic.hpp" "ToyMC.hpp" "Utils.hpp" "BranchHashHelper.hpp" "HelperFunctions.hpp")
 
-include_directories(${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR} $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
 add_library(AnalysisTreeInfra SHARED ${SOURCES} G__AnalysisTreeInfra.cxx)
+target_include_directories(AnalysisTreeInfra PRIVATE ${CMAKE_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR} $<$<BOOL:${Boost_FOUND}>:${Boost_INCLUDE_DIRS}>)
 target_compile_definitions(AnalysisTreeInfra PUBLIC
         $<$<BOOL:${Boost_FOUND}>:ANALYSISTREE_BOOST_FOUND>)
 

--- a/infra/CMakeLists.txt
+++ b/infra/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     Branch.cpp
     BranchChannel.cpp
     AnalysisEntry.cpp
+    GenericContainerFiller.cpp
     )
 
 

--- a/infra/Chain.cpp
+++ b/infra/Chain.cpp
@@ -88,6 +88,10 @@ void Chain::InitPointersToBranches(std::set<std::string> names) {
         branch_ptr = new ModuleDetector;
         break;
       }
+      case DetType::kGeneric: {
+        branch_ptr = new GenericDetector;
+        break;
+      }
     }
     branches_.emplace(branch, branch_ptr);
   }

--- a/infra/GenericContainerFiller.cpp
+++ b/infra/GenericContainerFiller.cpp
@@ -1,0 +1,107 @@
+//
+// Created by oleksii on 09.04.25.
+//
+
+#include "GenericContainerFiller.hpp"
+
+#include <utility>
+
+using namespace AnalysisTree;
+
+GenericContainerFiller::GenericContainerFiller(std::string  fileInName, std::string  treeInName) : file_in_name_(std::move(fileInName)),
+                                                                                                   tree_in_name_(std::move(treeInName)) {}
+
+void GenericContainerFiller::Run(size_t nEntries) const {
+  TFile* fileIn = TFile::Open(file_in_name_.c_str(), "read");
+  if(fileIn == nullptr) throw std::runtime_error("GenericContainerFiller::Run(): fileIn == nullptr");
+
+  TTree* treeIn = fileIn->Get<TTree>(tree_in_name_.c_str());
+  if(treeIn == nullptr) throw std::runtime_error("GenericContainerFiller::Run(): treeIn == nullptr");
+
+  if(!fields_to_ignore_.empty() && !fields_to_preserve_.empty()) throw std::runtime_error("GenericContainerFiller::Run(): !fields_to_ignore_.empty() && !fields_to_preserve_.empty()");
+
+  const size_t nTreeEntries = treeIn->GetEntries();
+  const size_t nRunEntries = (nEntries<0 || nEntries>nTreeEntries) ? nTreeEntries : nEntries;
+
+  BranchConfig branchConfig(branch_out_name_, DetType::kGeneric);
+  std::vector<IndexMap> branchMap;
+  std::vector<FICS> branchValues;
+
+  auto lol = treeIn->GetListOfLeaves();
+  const int nLeaves = lol->GetEntries();
+  for(int iLeave=0; iLeave<nLeaves; iLeave++) {
+    auto leave = lol->At(iLeave);
+    const std::string fieldName = leave->GetName();
+    const std::string fieldType = leave->ClassName();
+    if (!fields_to_ignore_.empty() && (std::find(fields_to_ignore_.begin(), fields_to_ignore_.end(), fieldName) != fields_to_ignore_.end())) continue;
+    if (!fields_to_preserve_.empty() && (std::find(fields_to_preserve_.begin(), fields_to_preserve_.end(), fieldName) == fields_to_preserve_.end())) continue;
+    if (fieldType == "TLeafF") {
+      branchConfig.AddField<float>(fieldName);
+    } else if (fieldType == "TLeafI" || fieldType == "TLeafB" || fieldType == "TLeafS") {
+      branchConfig.AddField<int>(fieldName);
+    }
+    branchMap.emplace_back((IndexMap){fieldName, fieldType, branchConfig.GetFieldId(fieldName)});
+  }
+  branchValues.resize(branchMap.size());
+
+  Configuration config;
+  config.AddBranchConfig(branchConfig);
+
+  for(int iV=0; iV<branchValues.size(); iV++) {
+    TBranch* branch = treeIn->GetBranch(branchMap.at(iV).name_.c_str());
+    SetAddressFICS(branch, branchMap.at(iV), branchValues.at(iV));
+  }
+
+  GenericDetector* genericDetector = new GenericDetector(branchConfig.GetId());
+
+  const int entrySwitchTriggerId = entry_switch_trigger_var_name_.empty() ? -999 : DetermineFieldIdByName(branchMap, entry_switch_trigger_var_name_);
+
+  TFile* fileOut = TFile::Open(file_out_name_.c_str(), "recreate");
+  TTree* treeOut = new TTree(tree_out_name_.c_str(), "Analysis Tree");
+  treeOut->SetAutoSave(0);
+  treeOut->Branch((branchConfig.GetName() + ".").c_str(), "AnalysisTree::GenericDetector", &genericDetector);
+
+  int previousTriggerVar{-799};
+  for(int iEntry=0; iEntry<nRunEntries; iEntry++) {
+    treeIn->GetEntry(iEntry);
+    const int currentTriggerVar = entrySwitchTriggerId >= 0 ? branchValues.at(entrySwitchTriggerId).int_ : previousTriggerVar;
+    auto isNewATEntry = [&]() {return iEntry == 0 ||
+                                   (currentTriggerVar != previousTriggerVar) ||
+                                   (n_channels_per_entry_ >= 0 && iEntry % n_channels_per_entry_ == 0); };
+
+    if(isNewATEntry()) genericDetector->ClearChannels();
+    auto& channel = genericDetector->AddChannel(config.GetBranchConfig(genericDetector->GetId()));
+    SetFieldsFICS(branchMap, channel, branchValues);
+    if(isNewATEntry()) treeOut->Fill();
+  } // iEntry
+
+  fileOut->cd();
+  config.Write("Configuration");
+  treeOut->Write();
+  fileOut->Close();
+  fileIn->Close();
+}
+
+int GenericContainerFiller::DetermineFieldIdByName(const std::vector<IndexMap>& iMap, const std::string& name) {
+  auto distance = std::distance(iMap.begin(),std::find_if(iMap.begin(), iMap.end(), [&name](const IndexMap& p) { return p.name_ == name; }));
+  if(distance == iMap.size()) throw std::runtime_error("DetermineFieldIdByName(): name " + name + " is missing");
+  return distance;
+}
+
+void GenericContainerFiller::SetAddressFICS(TBranch* branch, const IndexMap& imap, FICS& ficc) {
+  if     (imap.field_type_ == "TLeafF") branch->SetAddress(&ficc.float_);
+  else if(imap.field_type_ == "TLeafI") branch->SetAddress(&ficc.int_);
+  else if(imap.field_type_ == "TLeafB") branch->SetAddress(&ficc.char_);
+  else if(imap.field_type_ == "TLeafS") branch->SetAddress(&ficc.short_);
+  else throw std::runtime_error("GenericContainerFiller::SetAddressFICS(): unsupported filed type " + imap.field_type_);
+}
+
+void GenericContainerFiller::SetFieldsFICS(const std::vector<IndexMap>& imap, Container& container, const std::vector<FICS>& ficc) {
+  for(int iV=0; iV<ficc.size(); iV++) {
+    if     (imap.at(iV).field_type_ == "TLeafF") container.SetField(ficc.at(iV).float_, imap.at(iV).index_);
+    else if(imap.at(iV).field_type_ == "TLeafI") container.SetField(ficc.at(iV).int_, imap.at(iV).index_);
+    else if(imap.at(iV).field_type_ == "TLeafB") container.SetField(static_cast<int>(ficc.at(iV).char_), imap.at(iV).index_);
+    else if(imap.at(iV).field_type_ == "TLeafS") container.SetField(static_cast<int>(ficc.at(iV).short_), imap.at(iV).index_);
+    else throw std::runtime_error("GenericContainerFiller::SetFieldsFICS(): unsupported filed type " + imap.at(iV).field_type_);
+  }
+}

--- a/infra/GenericContainerFiller.cpp
+++ b/infra/GenericContainerFiller.cpp
@@ -6,23 +6,23 @@
 
 using namespace AnalysisTree;
 
-GenericContainerFiller::GenericContainerFiller(std::string  fileInName, std::string  treeInName) : file_in_name_(std::move(fileInName)),
-                                                                                                   tree_in_name_(std::move(treeInName)) {}
+GenericContainerFiller::GenericContainerFiller(std::string fileInName, std::string treeInName) : file_in_name_(std::move(fileInName)),
+                                                                                                 tree_in_name_(std::move(treeInName)) {}
 
 void GenericContainerFiller::Init() {
   file_in_ = TFile::Open(file_in_name_.c_str(), "read");
-  if(file_in_ == nullptr) throw std::runtime_error("GenericContainerFiller::Run(): file_in_ == nullptr");
+  if (file_in_ == nullptr) throw std::runtime_error("GenericContainerFiller::Run(): file_in_ == nullptr");
 
   tree_in_ = file_in_->Get<TTree>(tree_in_name_.c_str());
-  if(tree_in_ == nullptr) throw std::runtime_error("GenericContainerFiller::Run(): tree_in_ == nullptr");
+  if (tree_in_ == nullptr) throw std::runtime_error("GenericContainerFiller::Run(): tree_in_ == nullptr");
 
-  if(!fields_to_ignore_.empty() && !fields_to_preserve_.empty()) throw std::runtime_error("GenericContainerFiller::Run(): !fields_to_ignore_.empty() && !fields_to_preserve_.empty()");
+  if (!fields_to_ignore_.empty() && !fields_to_preserve_.empty()) throw std::runtime_error("GenericContainerFiller::Run(): !fields_to_ignore_.empty() && !fields_to_preserve_.empty()");
 
   BranchConfig branchConfig(branch_out_name_, DetType::kGeneric);
 
   auto lol = tree_in_->GetListOfLeaves();
   const int nLeaves = lol->GetEntries();
-  for(int iLeave=0; iLeave<nLeaves; iLeave++) {
+  for (int iLeave = 0; iLeave < nLeaves; iLeave++) {
     auto leave = lol->At(iLeave);
     const std::string fieldName = leave->GetName();
     const std::string fieldType = leave->ClassName();
@@ -39,7 +39,7 @@ void GenericContainerFiller::Init() {
 
   config_.AddBranchConfig(branchConfig);
 
-  for(int iV=0; iV<branch_values_.size(); iV++) {
+  for (int iV = 0; iV < branch_values_.size(); iV++) {
     TBranch* branch = tree_in_->GetBranch(branch_map_.at(iV).name_.c_str());
     SetAddressFICS(branch, branch_map_.at(iV), branch_values_.at(iV));
   }
@@ -57,12 +57,10 @@ void GenericContainerFiller::Init() {
 int GenericContainerFiller::Exec(int iEntry, int previousTriggerVar) {
   tree_in_->GetEntry(iEntry);
   const int currentTriggerVar = entry_switch_trigger_id_ >= 0 ? branch_values_.at(entry_switch_trigger_id_).get() : previousTriggerVar;
-  auto isNewATEntry = [&]() {return iEntry == 0 ||
-                                  (currentTriggerVar != previousTriggerVar) ||
-                                  (n_channels_per_entry_ >= 0 && iEntry % n_channels_per_entry_ == 0); };
+  auto isNewATEntry = [&]() { return iEntry == 0 || (currentTriggerVar != previousTriggerVar) || (n_channels_per_entry_ >= 0 && iEntry % n_channels_per_entry_ == 0); };
 
-  if(isNewATEntry()) {
-    if(iEntry != 0) tree_out_->Fill();
+  if (isNewATEntry()) {
+    if (iEntry != 0) tree_out_->Fill();
     generic_detector_->ClearChannels();
   }
   auto& channel = generic_detector_->AddChannel(config_.GetBranchConfig(generic_detector_->GetId()));
@@ -83,37 +81,45 @@ void GenericContainerFiller::Run(int nEntries) {
   Init();
 
   const size_t nTreeEntries = tree_in_->GetEntries();
-  const size_t nRunEntries = (nEntries<0 || nEntries>nTreeEntries) ? nTreeEntries : nEntries;
+  const size_t nRunEntries = (nEntries < 0 || nEntries > nTreeEntries) ? nTreeEntries : nEntries;
 
   int previousTriggerVar{-799};
-  for(int iEntry=0; iEntry<nRunEntries; iEntry++) {
+  for (int iEntry = 0; iEntry < nRunEntries; iEntry++) {
     previousTriggerVar = Exec(iEntry, previousTriggerVar);
-  } // iEntry
+  }// iEntry
   tree_out_->Fill();
 
   Finish();
 }
 
 int GenericContainerFiller::DetermineFieldIdByName(const std::vector<IndexMap>& iMap, const std::string& name) {
-  auto distance = std::distance(iMap.begin(),std::find_if(iMap.begin(), iMap.end(), [&name](const IndexMap& p) { return p.name_ == name; }));
-  if(distance == iMap.size()) throw std::runtime_error("DetermineFieldIdByName(): name " + name + " is missing");
+  auto distance = std::distance(iMap.begin(), std::find_if(iMap.begin(), iMap.end(), [&name](const IndexMap& p) { return p.name_ == name; }));
+  if (distance == iMap.size()) throw std::runtime_error("DetermineFieldIdByName(): name " + name + " is missing");
   return distance;
 }
 
 void GenericContainerFiller::SetAddressFICS(TBranch* branch, const IndexMap& imap, FICS& ficc) {
-  if     (imap.field_type_ == "TLeafF") branch->SetAddress(&ficc.float_);
-  else if(imap.field_type_ == "TLeafI") branch->SetAddress(&ficc.int_);
-  else if(imap.field_type_ == "TLeafB") branch->SetAddress(&ficc.char_);
-  else if(imap.field_type_ == "TLeafS") branch->SetAddress(&ficc.short_);
-  else throw std::runtime_error("GenericContainerFiller::SetAddressFICS(): unsupported filed type " + imap.field_type_);
+  if (imap.field_type_ == "TLeafF") branch->SetAddress(&ficc.float_);
+  else if (imap.field_type_ == "TLeafI")
+    branch->SetAddress(&ficc.int_);
+  else if (imap.field_type_ == "TLeafB")
+    branch->SetAddress(&ficc.char_);
+  else if (imap.field_type_ == "TLeafS")
+    branch->SetAddress(&ficc.short_);
+  else
+    throw std::runtime_error("GenericContainerFiller::SetAddressFICS(): unsupported filed type " + imap.field_type_);
 }
 
 void GenericContainerFiller::SetFieldsFICS(const std::vector<IndexMap>& imap, Container& container, const std::vector<FICS>& ficc) {
-  for(int iV=0; iV<ficc.size(); iV++) {
-    if     (imap.at(iV).field_type_ == "TLeafF") container.SetField(ficc.at(iV).float_, imap.at(iV).index_);
-    else if(imap.at(iV).field_type_ == "TLeafI") container.SetField(ficc.at(iV).int_, imap.at(iV).index_);
-    else if(imap.at(iV).field_type_ == "TLeafB") container.SetField(static_cast<int>(ficc.at(iV).char_), imap.at(iV).index_);
-    else if(imap.at(iV).field_type_ == "TLeafS") container.SetField(static_cast<int>(ficc.at(iV).short_), imap.at(iV).index_);
-    else throw std::runtime_error("GenericContainerFiller::SetFieldsFICS(): unsupported filed type " + imap.at(iV).field_type_);
+  for (int iV = 0; iV < ficc.size(); iV++) {
+    if (imap.at(iV).field_type_ == "TLeafF") container.SetField(ficc.at(iV).float_, imap.at(iV).index_);
+    else if (imap.at(iV).field_type_ == "TLeafI")
+      container.SetField(ficc.at(iV).int_, imap.at(iV).index_);
+    else if (imap.at(iV).field_type_ == "TLeafB")
+      container.SetField(static_cast<int>(ficc.at(iV).char_), imap.at(iV).index_);
+    else if (imap.at(iV).field_type_ == "TLeafS")
+      container.SetField(static_cast<int>(ficc.at(iV).short_), imap.at(iV).index_);
+    else
+      throw std::runtime_error("GenericContainerFiller::SetFieldsFICS(): unsupported filed type " + imap.at(iV).field_type_);
   }
 }

--- a/infra/GenericContainerFiller.hpp
+++ b/infra/GenericContainerFiller.hpp
@@ -1,0 +1,73 @@
+//
+// Created by oleksii on 09.04.25.
+//
+
+#ifndef ANALYSISTREE_GENERICCONTAINERFILLER_HPP
+#define ANALYSISTREE_GENERICCONTAINERFILLER_HPP
+
+#include "AnalysisTask.hpp"
+
+#include <string>
+#include <vector>
+
+struct IndexMap {
+  std::string name_;
+  std::string field_type_;
+  short index_;
+};
+
+struct FICS { // FICS stands for float, int, char, short
+  float float_{-999.f};
+  int int_{-999};
+  char char_{static_cast<char>(-999)};
+  short short_{static_cast<short>(-999)};
+};
+
+namespace AnalysisTree {
+
+class GenericContainerFiller {
+ public:
+  GenericContainerFiller() = delete;
+  explicit GenericContainerFiller(std::string  fileInName, std::string  treeInName="pTree");
+  virtual ~GenericContainerFiller() = default;
+
+  void SetOutputFileName(const std::string& name) { file_out_name_ = name; }
+  void SetOutputTreeName(const std::string& name) { tree_out_name_ = name; }
+  void SetOutputBranchName(const std::string& name) { branch_out_name_ = name; }
+
+  void SetFieldsToIgnore(const std::vector<std::string>& fields) { fields_to_ignore_ = fields; }
+  void SetFieldsToPreserve(const std::vector<std::string>& fields) { fields_to_preserve_ = fields; }
+
+  void SetEntrySwitchTriggerVarName(const std::string& name) { entry_switch_trigger_var_name_ = name; }
+
+  void SetNChannelsPerEntry(int n) { n_channels_per_entry_ = n; }
+
+  void Run(size_t nEntries=-1) const;
+
+ protected:
+  static int DetermineFieldIdByName(const std::vector<IndexMap>& iMap, const std::string& name);
+  static void SetAddressFICS(TBranch* branch, const IndexMap& imap, FICS& ficc);
+  static void SetFieldsFICS(const std::vector<IndexMap>& imap, Container& container, const std::vector<FICS>& ficc);
+
+  std::string file_in_name_;
+  std::string tree_in_name_;
+
+  std::string file_out_name_{"AnalysisTree.root"};
+  std::string tree_out_name_{"aTree"};
+  std::string branch_out_name_{"PlainBranch"};
+
+  // variable, change of value of which triggers switch to a new AT event
+  std::string entry_switch_trigger_var_name_{""};
+
+  // if entry_switch_trigger_var_name_ is not empty, this field does not matter
+  // if entry_switch_trigger_var_name_ is empty, sets how many AT channels
+  // will constitute a single AT entry (event)
+  int n_channels_per_entry_{-1};
+
+  std::vector<std::string> fields_to_ignore_{};
+  std::vector<std::string> fields_to_preserve_{};
+
+
+};
+}
+#endif//ANALYSISTREE_GENERICCONTAINERFILLER_HPP

--- a/infra/GenericContainerFiller.hpp
+++ b/infra/GenericContainerFiller.hpp
@@ -21,17 +21,17 @@ struct IndexMap {
   short index_;
 };
 
-struct FICS { // FICS stands for float, int, char, short
+struct FICS {// FICS stands for float, int, char, short
   float float_{-199.f};
   int int_{-199};
   char char_{static_cast<char>(-199)};
   short short_{static_cast<short>(-199)};
 
   float get() {
-    if(std::fabs(float_ + 199.f) > 1e-4) return float_;
-    if(int_ != -199) return static_cast<float>(int_);
-    if(char_ != static_cast<char>(-199)) return static_cast<float>(char_);
-    if(short_ != static_cast<short>(-199)) return static_cast<float>(short_);
+    if (std::fabs(float_ + 199.f) > 1e-4) return float_;
+    if (int_ != -199) return static_cast<float>(int_);
+    if (char_ != static_cast<char>(-199)) return static_cast<float>(char_);
+    if (short_ != static_cast<short>(-199)) return static_cast<float>(short_);
     throw std::runtime_error("GenericContainerFiller, FICS::get(): none of values initialized");
   }
 };
@@ -41,7 +41,7 @@ namespace AnalysisTree {
 class GenericContainerFiller {
  public:
   GenericContainerFiller() = delete;
-  explicit GenericContainerFiller(std::string  fileInName, std::string  treeInName="pTree");
+  explicit GenericContainerFiller(std::string fileInName, std::string treeInName = "pTree");
   virtual ~GenericContainerFiller() = default;
 
   void SetOutputFileName(const std::string& name) { file_out_name_ = name; }
@@ -55,7 +55,7 @@ class GenericContainerFiller {
 
   void SetNChannelsPerEntry(int n) { n_channels_per_entry_ = n; }
 
-  void Run(int nEntries=-1);
+  void Run(int nEntries = -1);
 
  protected:
   void Init();
@@ -95,8 +95,6 @@ class GenericContainerFiller {
 
   std::vector<std::string> fields_to_ignore_{};
   std::vector<std::string> fields_to_preserve_{};
-
-
 };
-}
+}// namespace AnalysisTree
 #endif//ANALYSISTREE_GENERICCONTAINERFILLER_HPP

--- a/infra/GenericContainerFiller.hpp
+++ b/infra/GenericContainerFiller.hpp
@@ -5,7 +5,12 @@
 #ifndef ANALYSISTREE_GENERICCONTAINERFILLER_HPP
 #define ANALYSISTREE_GENERICCONTAINERFILLER_HPP
 
-#include "AnalysisTask.hpp"
+#include "Configuration.hpp"
+#include "Container.hpp"
+#include "Detector.hpp"
+
+#include <TFile.h>
+#include <TTree.h>
 
 #include <string>
 #include <vector>
@@ -17,10 +22,18 @@ struct IndexMap {
 };
 
 struct FICS { // FICS stands for float, int, char, short
-  float float_{-999.f};
-  int int_{-999};
-  char char_{static_cast<char>(-999)};
-  short short_{static_cast<short>(-999)};
+  float float_{-199.f};
+  int int_{-199};
+  char char_{static_cast<char>(-199)};
+  short short_{static_cast<short>(-199)};
+
+  float get() {
+    if(std::fabs(float_ + 199.f) > 1e-4) return float_;
+    if(int_ != -199) return static_cast<float>(int_);
+    if(char_ != static_cast<char>(-199)) return static_cast<float>(char_);
+    if(short_ != static_cast<short>(-199)) return static_cast<float>(short_);
+    throw std::runtime_error("GenericContainerFiller, FICS::get(): none of values initialized");
+  }
 };
 
 namespace AnalysisTree {
@@ -42,12 +55,16 @@ class GenericContainerFiller {
 
   void SetNChannelsPerEntry(int n) { n_channels_per_entry_ = n; }
 
-  void Run(size_t nEntries=-1) const;
+  void Run(int nEntries=-1);
 
  protected:
+  void Init();
+  int Exec(int iEntry, int previousTriggerVar);
+  void Finish();
+
   static int DetermineFieldIdByName(const std::vector<IndexMap>& iMap, const std::string& name);
   static void SetAddressFICS(TBranch* branch, const IndexMap& imap, FICS& ficc);
-  static void SetFieldsFICS(const std::vector<IndexMap>& imap, Container& container, const std::vector<FICS>& ficc);
+  static void SetFieldsFICS(const std::vector<IndexMap>& imap, AnalysisTree::Container& container, const std::vector<FICS>& ficc);
 
   std::string file_in_name_;
   std::string tree_in_name_;
@@ -56,8 +73,20 @@ class GenericContainerFiller {
   std::string tree_out_name_{"aTree"};
   std::string branch_out_name_{"PlainBranch"};
 
+  TFile* file_in_{nullptr};
+  TTree* tree_in_{nullptr};
+  TFile* file_out_{nullptr};
+  TTree* tree_out_{nullptr};
+
+  AnalysisTree::Configuration config_;
+  AnalysisTree::GenericDetector* generic_detector_{nullptr};
+  std::vector<IndexMap> branch_map_;
+  std::vector<FICS> branch_values_;
+
   // variable, change of value of which triggers switch to a new AT event
   std::string entry_switch_trigger_var_name_{""};
+
+  int entry_switch_trigger_id_{-1};
 
   // if entry_switch_trigger_var_name_ is not empty, this field does not matter
   // if entry_switch_trigger_var_name_ is empty, sets how many AT channels

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -33,7 +33,7 @@ inline std::string ToStringWithSignificantFigures(const T a_value, const int n) 
 inline std::vector<AnalysisTree::SimpleCut> CreateRangeCuts(const std::vector<float>& ranges, const std::string& cutNamePrefix, const std::string& branchFieldName, int precision = 2) {
   std::vector<AnalysisTree::SimpleCut> sliceCuts;
   for (int iRange = 0; iRange < ranges.size() - 1; iRange++) {
-    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), 2) + "_" + ToStringWithPrecision(ranges.at(iRange + 1), precision);
+    const std::string cutName = cutNamePrefix + ToStringWithPrecision(ranges.at(iRange), precision) + "_" + ToStringWithPrecision(ranges.at(iRange + 1), precision);
     sliceCuts.emplace_back(AnalysisTree::RangeCut(branchFieldName, ranges.at(iRange), ranges.at(iRange + 1), cutName));
   }
 

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -51,9 +51,11 @@ inline std::vector<AnalysisTree::SimpleCut> CreateEqualCuts(const std::vector<fl
 }
 
 inline bool StringToBool(const std::string& str) {
-  if(str == "true") return true;
-  else if(str == "false") return false;
-  else throw std::runtime_error("HelperFunctions::StringToBool(): argument must be either true or false");
+  if (str == "true") return true;
+  else if (str == "false")
+    return false;
+  else
+    throw std::runtime_error("HelperFunctions::StringToBool(): argument must be either true or false");
 }
 
 }// namespace HelperFunctions

--- a/infra/HelperFunctions.hpp
+++ b/infra/HelperFunctions.hpp
@@ -50,5 +50,11 @@ inline std::vector<AnalysisTree::SimpleCut> CreateEqualCuts(const std::vector<fl
   return sliceCuts;
 }
 
+inline bool StringToBool(const std::string& str) {
+  if(str == "true") return true;
+  else if(str == "false") return false;
+  else throw std::runtime_error("HelperFunctions::StringToBool(): argument must be either true or false");
+}
+
 }// namespace HelperFunctions
 #endif// ANALYSISTREE_INFRA_HELPER_FUNCTIONS_HPP

--- a/infra/TaskManager.hpp
+++ b/infra/TaskManager.hpp
@@ -107,6 +107,10 @@ class TaskManager {
         AddBranch(branch->GetDataRaw<EventHeader*>(), branch->GetConfig());
         break;
       }
+      case DetType::kGeneric: {
+        AddBranch(branch->GetDataRaw<GenericDetector*>(), branch->GetConfig());
+        break;
+      }
     }
   }
 
@@ -126,9 +130,6 @@ class TaskManager {
                          configuration_->GetBranchConfig(br2).GetId());
 
     configuration_->AddMatch(match);
-    //    if (write_mode_ == eBranchWriteMode::kCreateNewTree) {
-    //      chain_->GetConfiguration()->AddMatch(match);
-    //    }
     out_tree_->Branch((configuration_->GetMatchName(br1, br2) + ".").c_str(), &match);
   }
 

--- a/infra/Utils.hpp
+++ b/infra/Utils.hpp
@@ -32,9 +32,10 @@ class Particle;
 class Module;
 class Hit;
 class EventHeader;
+class Container;
 
-using BranchPointer = ANALYSISTREE_UTILS_VARIANT<HitDetector*, ModuleDetector*, TrackDetector*, EventHeader*, Particles*>;
-using ChannelPointer = ANALYSISTREE_UTILS_VARIANT<Hit*, Module*, Track*, EventHeader*, Particle*>;
+using BranchPointer = ANALYSISTREE_UTILS_VARIANT<HitDetector*, ModuleDetector*, TrackDetector*, EventHeader*, Particles*, GenericDetector*>;
+using ChannelPointer = ANALYSISTREE_UTILS_VARIANT<Hit*, Module*, Track*, EventHeader*, Particle*, Container*>;
 
 namespace Utils {
 


### PR DESCRIPTION
1. Enabled filling of a `GenericContainer` - the channelized object like `Hit`, `Track`, `Particle`, but without default fields (this opportunity was previously envisioned but not taken to its logical conclusion).
2. Created a `GenericContainerFiller` class - with functionality complementary to `PlainTreeFiller`.
3. Fixed some compilation and linker warnings *
4. Cosmetics changes.

*) There was a linker warning after compilation of the `examples` directory: `Warning: Unused class rule: UserTaskWrite`. It's worth noting that the linker error was related only to the first .cpp (and .hpp) entry in the CMakeLists.txt, e.g. `UserTaskRead` did not produce such an error. In the newly generated `G__AnalysisTreeUser.cxx` file among "Header files passed as explicit arguments" the `UserTaskWrite.hpp` was missing. It turned out, that the `rootcling` command called by ROOT_GENERATE_DICTIONARY() function, by mistake prepended the list of headers with a key `-I`, however this key should be used only with directories, not files. Therefore the first header was wrongly considered as a directory, that produced the described above behavior.
This problem was addressed by replacing the **include_directories**() function with the **target_include_directories**().
P.S. The same function, **include_directories**(), was used in the CMakeLists.txt of the `infra` directory, however there was no such a linker error there. The point is that although the first header, `SimpleCut.hpp`, was missing in the `G__AnalysisTreeInfra.cxx`, it was present in other headers, which were included further (e.g. in `Cuts.hpp`).
P.P.S. If for any reasons you cannot refrain from using the **include_directories**(), the mentioned linker error can be addressed in a different way: (1) remove `G__AnalysisTreeUser.cxx` from the **add_library**() function; (2) add `MODULE AnalysisTreeUser` in the ROOT_GENERATE_DICTIONARY() function.
But in general, **include_directories**() usage is deprecated and should be avoided where possible.