### PR TITLE
Maintain GenericContainer- and PlainTreeFiller

### DIFF
--- a/infra/GenericContainerFiller.cpp
+++ b/infra/GenericContainerFiller.cpp
@@ -19,7 +19,7 @@ void GenericContainerFiller::Init() {
     return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
   };
 
-  if(ends_with(file_in_name_, ".root")) {
+  if (ends_with(file_in_name_, ".root")) {
     tree_in_->Add(file_in_name_.c_str());
   } else {
     std::ifstream filelist(file_in_name_);

--- a/infra/GenericContainerFiller.cpp
+++ b/infra/GenericContainerFiller.cpp
@@ -56,8 +56,7 @@ void GenericContainerFiller::Init() {
   config_.AddBranchConfig(branchConfig);
 
   for (int iV = 0; iV < branch_values_.size(); iV++) {
-    TBranch* branch = tree_in_->GetBranch(branch_map_.at(iV).name_.c_str());
-    SetAddressFICS(branch, branch_map_.at(iV), branch_values_.at(iV));
+    SetAddressFICS(branch_map_.at(iV).name_, branch_map_.at(iV), branch_values_.at(iV));
   }
 
   generic_detector_ = new GenericDetector(branchConfig.GetId());
@@ -114,14 +113,14 @@ int GenericContainerFiller::DetermineFieldIdByName(const std::vector<IndexMap>& 
   return distance;
 }
 
-void GenericContainerFiller::SetAddressFICS(TBranch* branch, const IndexMap& imap, FICS& ficc) {
-  if (imap.field_type_ == "TLeafF") branch->SetAddress(&ficc.float_);
+void GenericContainerFiller::SetAddressFICS(const std::string& branchName, const IndexMap& imap, FICS& ficc) {
+  if (imap.field_type_ == "TLeafF") tree_in_->SetBranchAddress(branchName.c_str(), &ficc.float_);
   else if (imap.field_type_ == "TLeafI")
-    branch->SetAddress(&ficc.int_);
+    tree_in_->SetBranchAddress(branchName.c_str(), &ficc.int_);
   else if (imap.field_type_ == "TLeafB")
-    branch->SetAddress(&ficc.char_);
+    tree_in_->SetBranchAddress(branchName.c_str(), &ficc.char_);
   else if (imap.field_type_ == "TLeafS")
-    branch->SetAddress(&ficc.short_);
+    tree_in_->SetBranchAddress(branchName.c_str(), &ficc.short_);
   else
     throw std::runtime_error("GenericContainerFiller::SetAddressFICS(): unsupported filed type " + imap.field_type_);
 }

--- a/infra/GenericContainerFiller.hpp
+++ b/infra/GenericContainerFiller.hpp
@@ -27,7 +27,7 @@ struct FICS {// FICS stands for float, int, char, short
   char char_{static_cast<char>(-199)};
   short short_{static_cast<short>(-199)};
 
-  float get() {
+  float get() const {
     if (std::fabs(float_ + 199.f) > 1e-4) return float_;
     if (int_ != -199) return static_cast<float>(int_);
     if (char_ != static_cast<char>(-199)) return static_cast<float>(char_);
@@ -83,7 +83,7 @@ class GenericContainerFiller {
   std::vector<FICS> branch_values_;
 
   // variable, change of value of which triggers switch to a new AT event
-  std::string entry_switch_trigger_var_name_{""};
+  std::string entry_switch_trigger_var_name_;
 
   int entry_switch_trigger_id_{-1};
 

--- a/infra/GenericContainerFiller.hpp
+++ b/infra/GenericContainerFiller.hpp
@@ -9,8 +9,8 @@
 #include "Container.hpp"
 #include "Detector.hpp"
 
+#include <TChain.h>
 #include <TFile.h>
-#include <TTree.h>
 
 #include <string>
 #include <vector>
@@ -73,8 +73,7 @@ class GenericContainerFiller {
   std::string tree_out_name_{"aTree"};
   std::string branch_out_name_{"PlainBranch"};
 
-  TFile* file_in_{nullptr};
-  TTree* tree_in_{nullptr};
+  TChain* tree_in_{nullptr};
   TFile* file_out_{nullptr};
   TTree* tree_out_{nullptr};
 

--- a/infra/GenericContainerFiller.hpp
+++ b/infra/GenericContainerFiller.hpp
@@ -63,7 +63,7 @@ class GenericContainerFiller {
   void Finish();
 
   static int DetermineFieldIdByName(const std::vector<IndexMap>& iMap, const std::string& name);
-  static void SetAddressFICS(TBranch* branch, const IndexMap& imap, FICS& ficc);
+  void SetAddressFICS(const std::string& branchName, const IndexMap& imap, FICS& ficc);
   static void SetFieldsFICS(const std::vector<IndexMap>& imap, AnalysisTree::Container& container, const std::vector<FICS>& ficc);
 
   std::string file_in_name_;

--- a/infra/PlainTreeFiller.cpp
+++ b/infra/PlainTreeFiller.cpp
@@ -77,7 +77,7 @@ void PlainTreeFiller::Init() {
   }
   const auto& vars = entries_[0].GetVariables();
 
-  if(vars_.size() != vars.size()) throw std::runtime_error("PlainTreeFiller::Init(): vars_.size() != vars.size()");
+  if (vars_.size() != vars.size()) throw std::runtime_error("PlainTreeFiller::Init(): vars_.size() != vars.size()");
 
   file_ = TFile::Open(file_name_.c_str(), "recreate");
   plain_tree_ = new TTree(tree_name_.c_str(), "Plain Tree");
@@ -88,9 +88,9 @@ void PlainTreeFiller::Init() {
     if (!fields_to_preserve_.empty() && std::find(fields_to_preserve_.begin(), fields_to_preserve_.end(), leaf_name) == fields_to_preserve_.end()) continue;
     if (!is_prepend_leaves_with_branchname_) leaf_name.erase(0, branch_name_.size() + 1);
     std::replace(leaf_name.begin(), leaf_name.end(), '.', '_');
-    if(vars_.at(i).type_ == Types::kFloat) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).float_, Form("%s/F", leaf_name.c_str()));
-    if(vars_.at(i).type_ == Types::kInteger) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).int_, Form("%s/I", leaf_name.c_str()));
-    if(vars_.at(i).type_ == Types::kBool) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).bool_, Form("%s/O", leaf_name.c_str()));
+    if (vars_.at(i).type_ == Types::kFloat) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).float_, Form("%s/F", leaf_name.c_str()));
+    if (vars_.at(i).type_ == Types::kInteger) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).int_, Form("%s/I", leaf_name.c_str()));
+    if (vars_.at(i).type_ == Types::kBool) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).bool_, Form("%s/O", leaf_name.c_str()));
   }
 
   for (auto& cm : cuts_map_) {
@@ -106,9 +106,9 @@ void PlainTreeFiller::Exec() {
   for (const auto& channel : values) {
     assert(channel.size() == vars_.size());
     for (size_t i = 0; i < channel.size(); ++i) {
-      if(vars_.at(i).type_ == Types::kFloat) vars_.at(i).float_ = static_cast<float>(channel.at(i));
-      if(vars_.at(i).type_ == Types::kInteger) vars_.at(i).int_ = static_cast<int>(channel.at(i));
-      if(vars_.at(i).type_ == Types::kBool) vars_.at(i).bool_ = static_cast<bool>(channel.at(i));
+      if (vars_.at(i).type_ == Types::kFloat) vars_.at(i).float_ = static_cast<float>(channel.at(i));
+      if (vars_.at(i).type_ == Types::kInteger) vars_.at(i).int_ = static_cast<int>(channel.at(i));
+      if (vars_.at(i).type_ == Types::kBool) vars_.at(i).bool_ = static_cast<bool>(channel.at(i));
     }
     plain_tree_->Fill();
   }

--- a/infra/PlainTreeFiller.cpp
+++ b/infra/PlainTreeFiller.cpp
@@ -89,8 +89,10 @@ void PlainTreeFiller::Init() {
     if (!is_prepend_leaves_with_branchname_) leaf_name.erase(0, branch_name_.size() + 1);
     std::replace(leaf_name.begin(), leaf_name.end(), '.', '_');
     if (vars_.at(i).type_ == Types::kFloat) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).float_, Form("%s/F", leaf_name.c_str()));
-    if (vars_.at(i).type_ == Types::kInteger) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).int_, Form("%s/I", leaf_name.c_str()));
-    if (vars_.at(i).type_ == Types::kBool) plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).bool_, Form("%s/O", leaf_name.c_str()));
+    else if (vars_.at(i).type_ == Types::kInteger)
+      plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).int_, Form("%s/I", leaf_name.c_str()));
+    else if (vars_.at(i).type_ == Types::kBool)
+      plain_tree_->Branch(leaf_name.c_str(), &vars_.at(i).bool_, Form("%s/O", leaf_name.c_str()));
   }
 
   for (auto& cm : cuts_map_) {
@@ -107,8 +109,10 @@ void PlainTreeFiller::Exec() {
     assert(channel.size() == vars_.size());
     for (size_t i = 0; i < channel.size(); ++i) {
       if (vars_.at(i).type_ == Types::kFloat) vars_.at(i).float_ = static_cast<float>(channel.at(i));
-      if (vars_.at(i).type_ == Types::kInteger) vars_.at(i).int_ = static_cast<int>(channel.at(i));
-      if (vars_.at(i).type_ == Types::kBool) vars_.at(i).bool_ = static_cast<bool>(channel.at(i));
+      else if (vars_.at(i).type_ == Types::kInteger)
+        vars_.at(i).int_ = static_cast<int>(std::round(channel.at(i)));
+      else if (vars_.at(i).type_ == Types::kBool)
+        vars_.at(i).bool_ = static_cast<bool>(std::round(channel.at(i)));
     }
     plain_tree_->Fill();
   }

--- a/infra/PlainTreeFiller.cpp
+++ b/infra/PlainTreeFiller.cpp
@@ -16,7 +16,7 @@ void PlainTreeFiller::AddBranch(const std::string& branch_name) {
 }
 
 void PlainTreeFiller::SetFieldsToIgnore(const std::vector<std::string>& fields_to_ignore) {
-  if (branch_name_ == "") {
+  if (branch_name_.empty()) {
     throw std::runtime_error("PlainTreeFiller::SetFieldsToIgnore() must be called after PlainTreeFiller::AddBranch()\n");
   }
   for (auto& fti : fields_to_ignore) {
@@ -25,7 +25,7 @@ void PlainTreeFiller::SetFieldsToIgnore(const std::vector<std::string>& fields_t
 }
 
 void PlainTreeFiller::SetFieldsToPreserve(const std::vector<std::string>& fields_to_preserve) {
-  if (branch_name_ == "") {
+  if (branch_name_.empty()) {
     throw std::runtime_error("PlainTreeFiller::SetFieldsToPreserve() must be called after PlainTreeFiller::AddBranch()\n");
   }
   for (auto& fti : fields_to_preserve) {
@@ -44,7 +44,7 @@ void PlainTreeFiller::Init() {
         if (me.second.id_ < 0) defaultFieldsNames.emplace_back(me.first);
       }
     }
-    SetFieldsToIgnore(std::move(defaultFieldsNames));
+    SetFieldsToIgnore(defaultFieldsNames);
   }
 
   if (!fields_to_ignore_.empty() && !fields_to_preserve_.empty()) {
@@ -55,17 +55,17 @@ void PlainTreeFiller::Init() {
     const auto& branch_config = config_->GetBranchConfig(branch_name_);
     for (const auto& field : branch_config.GetMap<float>()) {
       AnalysisTask::AddEntry(AnalysisEntry({Variable(branch_name_, field.first)}));
-      vars_.emplace_back(FIB());
+      vars_.emplace_back();
       vars_.back().type_ = Types::kFloat;
     }
     for (const auto& field : branch_config.GetMap<int>()) {
       AnalysisTask::AddEntry(AnalysisEntry({Variable(branch_name_, field.first)}));
-      vars_.emplace_back(FIB());
+      vars_.emplace_back();
       vars_.back().type_ = Types::kInteger;
     }
     for (const auto& field : branch_config.GetMap<bool>()) {
       AnalysisTask::AddEntry(AnalysisEntry({Variable(branch_name_, field.first)}));
-      vars_.emplace_back(FIB());
+      vars_.emplace_back();
       vars_.back().type_ = Types::kBool;
     }
   }

--- a/infra/PlainTreeFiller.hpp
+++ b/infra/PlainTreeFiller.hpp
@@ -12,6 +12,13 @@
 
 namespace AnalysisTree {
 
+struct FIB {
+  float float_{-299.f};
+  int int_{-299};
+  bool bool_{false};
+  Types type_{Types::kNumberOfTypes};
+};
+
 class PlainTreeFiller : public AnalysisTask {
  public:
   PlainTreeFiller() = default;
@@ -41,7 +48,7 @@ class PlainTreeFiller : public AnalysisTask {
   std::string tree_name_{"PlainTree"};
   std::string branch_name_;
 
-  std::vector<float> vars_{};
+  std::vector<FIB> vars_;
   std::vector<std::string> fields_to_ignore_{};
   std::vector<std::string> fields_to_preserve_{};
 


### PR DESCRIPTION
1. Enabled `GenericContainerFiller` run based on several plain root files written in the filelist.
2. In `PlainTreeFiller` write **float**, **int** and **bool** fields from the AnalysisTree into plain branches of corresponding type (before all of them were float).
3. Cosmetics.