### PR TITLE
Remove redundant template parser disambiguator

### DIFF
--- a/infra/Variable.hpp
+++ b/infra/Variable.hpp
@@ -71,7 +71,7 @@ class Variable {
     assert(is_init_ && n_branches_ == 1);
     vars_.clear();
     for (const auto& field : fields_) {
-      vars_.emplace_back(field.template GetValue(object));
+      vars_.emplace_back(field.GetValue(object));
     }
     return lambda_(vars_);
   }


### PR DESCRIPTION
The code crashed with ROOT 6.40, while it worked with older versions (probably change of clang from 18.1.8 to 20.1.8 matters). Removal of the keyword **template**  fixes the error.
For details see Issue https://github.com/HeavyIonAnalysis/AnalysisTree/issues/148